### PR TITLE
fix sunspot solr in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ before_install:
   - "cp config/database.yml.example config/database.yml"
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-before_script: RAILS_ENV=test rake sunspot:solr:start
+before_script: 
+  - RAILS_ENV=test rake sunspot:solr:start
+  - script/wait_for_solr.sh 8981
 after_script: RAILS_ENV=test rake sunspot:solr:stop
 

--- a/script/wait_for_solr.sh
+++ b/script/wait_for_solr.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+solr_responding() {
+  url=$1
+  echo "Trying to connect to $url"
+  curl -o /dev/null $url > /dev/null 2>&1
+}
+
+if [ $# -ne 1 ];then
+  echo "Usage $0 PORT"
+  echo "Where PORT is the port where solr is listening."
+  exit 1
+fi
+
+port=$1
+retries=0
+MAX_RETRIES=120
+url="http://localhost:$port/solr/admin/ping"
+
+while ! solr_responding $url; do
+  retries=$(( $retries + 1 ))
+  if [ $retries -gt $MAX_RETRIES ];then
+    echo "Sorry solr is not responding. I have tried connecting to $url for $MAX_RETRIES seconds without luck. Exiting..."
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "Solr is running on $url"
+
+
+


### PR DESCRIPTION
in travis sometimes the tests fail because solr is not responding. We
believe this is a timeout thing.

This commit adds a script that waits for solr to respond and this is run
before the tests.
