### PR TITLE
update rails and its dependencies including i18n and nokogiri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
 before_script: 
-  - RAILS_ENV=test rake sunspot:solr:start
+  - RAILS_ENV=test bundle exec rake sunspot:solr:start
   - script/wait_for_solr.sh 8981
-after_script: RAILS_ENV=test rake sunspot:solr:stop
+after_script: RAILS_ENV=test bundle exec rake sunspot:solr:stop
 

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,8 @@ gem 'figaro'
 # Use mousetrap for keyboard shortcuts
 gem 'mousetrap-rails'
 # Use sunspot/solr as search engine
-gem 'sunspot_rails'
-gem 'sunspot_solr'
+gem 'sunspot_rails', "~> 2.0.0"
+gem 'sunspot_solr', "~> 2.0.0"
 gem 'progress_bar', group: [:development]
 # Use capybara as test framework
 gem 'capybara', group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,11 +71,11 @@ GEM
     gravtastic (3.2.6)
     haml (4.0.5)
       tilt
-    haml-rails (0.5.1)
-      actionpack (~> 4.0.0)
-      activesupport (~> 4.0.0)
+    haml-rails (0.5.3)
+      actionpack (>= 4.0.1)
+      activesupport (>= 4.0.1)
       haml (>= 3.1, < 5.0)
-      railties (~> 4.0.0)
+      railties (>= 4.0.1)
     highline (1.6.21)
     hike (1.2.3)
     hoptoad_notifier (2.4.11)
@@ -152,14 +152,13 @@ GEM
       activesupport (>= 3.0)
       sprockets (~> 2.8)
     sqlite3 (1.3.9)
-    sunspot (2.1.0)
+    sunspot (2.0.0)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
-    sunspot_rails (2.1.0)
+    sunspot_rails (2.0.0)
       nokogiri
-      rails (>= 3)
-      sunspot (= 2.1.0)
-    sunspot_solr (2.1.0)
+      sunspot (= 2.0.0)
+    sunspot_solr (2.0.0)
     thor (0.19.1)
     thread_safe (0.3.3)
     tilt (1.4.1)
@@ -205,6 +204,6 @@ DEPENDENCIES
   simplecov
   single_test
   sqlite3
-  sunspot_rails
-  sunspot_solr
+  sunspot_rails (~> 2.0.0)
+  sunspot_solr (~> 2.0.0)
   uglifier (>= 1.3.0)


### PR DESCRIPTION
for fixing these security issues:

CVE-2013-6415
CVE-2013-4491
CVE-2013-6417
CVE-2013-6416
CVE-2013-4492
CVE-2013-6460
CVE-2013-6461
CVE-2014-0081
CVE-2014-0080
CVE-2013-6414
