### PR TITLE
fix encoding for user tests

### DIFF
--- a/test/integration/user_setup_test.rb
+++ b/test/integration/user_setup_test.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 require 'test_helper'
 
 class UserSetupTest < ActionDispatch::IntegrationTest

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -1,3 +1,4 @@
+#encoding: utf-8
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase


### PR DESCRIPTION
without explicitelly setting the encoding in the file, user tests where
failing in my workstation.
