### PR TITLE
Vagrantified development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 /tmp
 
 # Ignore the configuration files
-/config/database.yml
 /config/application.yml
 /config/secrets.yml
 

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ nbproject
 *.ipr
 *.iws
 .idea/
+.vagrant/

--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ end
 
 # as databases
 gem 'mysql2'
+gem 'sqlite3' # Required for Travis-CI tests
 # for stylesheets
 gem 'sass-rails',   '~> 5.0'
 # for .js.coffee assets

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ end
 
 # as databases
 gem 'mysql2'
-gem 'sqlite3'
 # for stylesheets
 gem 'sass-rails',   '~> 5.0'
 # for .js.coffee assets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
     sunspot (2.1.1)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
@@ -337,6 +338,7 @@ DEPENDENCIES
   selectize-rails
   spring
   spring-commands-rspec
+  sqlite3
   sunspot_rails (~> 2.1)
   sunspot_solr (~> 2.1)
   sunspot_test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,6 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
-    sqlite3 (1.3.10)
     sunspot (2.1.1)
       pr_geohash (~> 1.0)
       rsolr (~> 1.0.7)
@@ -338,7 +337,6 @@ DEPENDENCIES
   selectize-rails
   spring
   spring-commands-rspec
-  sqlite3
   sunspot_rails (~> 2.1)
   sunspot_solr (~> 2.1)
   sunspot_test

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ As our project involves somewhat complicated setup (MySQL and Shpinx search) eve
 3. Install vagrant-exec plugin: `vagrant plugin install vagrant-exec`.
 4. Start Vagrant box: `vagrant up`. It will set up and start an OpenSUSE 13.2 VirtualBox VM in the background. 
 VM will have a shared folder `/vagrant` with your code, and can always be shut down with `vagrant halt` and removed with `vagrant destroy`.
-5. Remote connection to the Vagrant box is available with `vagrant ssh`, one can run single-shot remote commands like `vagrant exec rake db:migrate` (will be run in the context of `/vagrant` folder).\
+5. Remote connection to the Vagrant box is available with `vagrant ssh`, one can run single-shot remote commands like `vagrant exec rake db:migrate` (will be run in the context of `/vagrant` folder; no need to additional state `bundle exec`, it is handled automatically).
 6. Install missing gems: `vagrant exec bundle`
 7. Migrate development database: `vagrant exec rake db:migrate`
 8. Launch the application: `vagrant exec rails s`. It should be running at http://localhost:3000, as usual.

--- a/README.md
+++ b/README.md
@@ -68,12 +68,12 @@ Because of sunspot solr, it requires java. We have installed java-1_7_0-ibm.
 
 As our project involves somewhat complicated setup (MySQL and Shpinx search) even for development environment, we've created Vagrantfile to get you up and running.
 
-1. Install Virtualbox for your OS.
+1. Install Virtualbox (can be found in your OS package manager or [here](https://www.virtualbox.org/wiki/Downloads)).
 2. Download and install the [latest vagrant](https://www.vagrantup.com/downloads.html).
 3. Install vagrant-exec plugin: `vagrant plugin install vagrant-exec`.
 4. Start Vagrant box: `vagrant up`. It will set up and start an OpenSUSE 13.2 VirtualBox VM in the background. 
-VM will have a shared folder `/vagrant` with your code, and can always be shut down with `vagrant halt` and removed with `vagrant destroy`.
-5. Remote connection to the Vagrant box is available with `vagrant ssh`, one can run single-shot remote commands like `vagrant exec rake db:migrate` (will be run in the context of `/vagrant` folder; no need to additional state `bundle exec`, it is handled automatically).
-6. Install missing gems: `vagrant exec bundle`
-7. Migrate development database: `vagrant exec rake db:migrate`
-8. Launch the application: `vagrant exec rails s`. It should be running at http://localhost:3000, as usual.
+VM will have an autosynced folder `/vagrant` with your code, and can always be shut down with `vagrant halt` and removed with `vagrant destroy`.
+5. Remote connection to the Vagrant box is available with `vagrant ssh`, one can run single-shot remote commands like `vagrant exec rake db:migrate` (will be run in the context of `/vagrant` folder; no need to additionaly state `bundle exec`).
+6. Install missing gems: `vagrant exec bundle`.
+7. Migrate development database: `vagrant exec rake db:migrate`.
+8. Launch the application: `vagrant exec rails s`. It should be accessible at http://localhost:3000, as usual.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,18 @@ rspec spec
 
 ## Requirements
 Because of sunspot solr, it requires java. We have installed java-1_7_0-ibm.
+
+
+# Development with Vagrant
+
+As our project involves somewhat complicated setup (MySQL and Shpinx search) even for development environment, we've created Vagrantfile to get you up and running.
+
+1. Install Virtualbox for your OS.
+2. Download and install the [latest vagrant](https://www.vagrantup.com/downloads.html).
+3. Install vagrant-exec plugin: `vagrant plugin install vagrant-exec`.
+4. Start Vagrant box: `vagrant up`. It will set up and start an OpenSUSE 13.2 VirtualBox VM in the background. 
+VM will have a shared folder `/vagrant` with your code, and can always be shut down with `vagrant halt` and removed with `vagrant destroy`.
+5. Remote connection to the Vagrant box is available with `vagrant ssh`, one can run single-shot remote commands like `vagrant exec rake db:migrate` (will be run in the context of `/vagrant` folder).\
+6. Install missing gems: `vagrant exec bundle`
+7. Migrate development database: `vagrant exec rake db:migrate`
+8. Launch the application: `vagrant exec rails s`. It should be running at http://localhost:3000, as usual.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,60 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box = 'webhippie/opensuse-13.2'
+
+  # The url from where the 'config.vm.box' box will be fetched if it
+  # doesn't already exist on the user's system.
+  # config.vm.box_url = "http://domain.com/path/to/above.box"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  config.vm.network :forwarded_port, guest: 3000, host: 3000
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network :private_network, ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network :public_network
+
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # Provision the box with a simple shell script
+  config.vm.provision :shell, path: 'bootstrap.sh'
+end

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ zypper addrepo -f 'http://download.opensuse.org/repositories/server:/search/open
 zypper --gpg-auto-import-keys refresh
 
 # Install required packages
-zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler libxml2-devel libxslt-devel
+zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler libxml2-devel libxslt-devel nodejs
 
 # Enable MySQL service — now and on startup
 chkconfig mysql on

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Add repository for Sphinx search
+zypper addrepo -f 'http://download.opensuse.org/repositories/server:/search/openSUSE_13.2/server:search.repo'
+zypper --gpg-auto-import-keys refresh
+
+# Install required packages
+zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler
+
+# Enable MySQL service — now and on startup
+chkconfig mysql on
+service mysql start
+
+# Setup hackweek_development database
+mysql -e "CREATE DATABASE IF NOT EXISTS hackweek_development DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
+mysql -e "GRANT ALL PRIVILEGES on hackweek_development.* to hackweek@localhost identified by 'S3cr3t';"
+
+# Setup hackweel_test database
+mysql -e "CREATE DATABASE IF NOT EXISTS hackweek_test DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;"
+mysql -e "GRANT ALL PRIVILEGES on hackweek_test.* to hackweek@localhost identified by 'S3cr3t';"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ zypper addrepo -f 'http://download.opensuse.org/repositories/server:/search/open
 zypper --gpg-auto-import-keys refresh
 
 # Install required packages
-zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler
+zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler libxml2-devel libxslt-devel
 
 # Enable MySQL service — now and on startup
 chkconfig mysql on

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -4,3 +4,16 @@ require 'rubygems'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])
+
+# The following is a monkey-patch to allow rails development server to listen on any interface
+# In 4.2, `rails s` starts server on localhost only, which is not suitable for our Vagrant setup
+require 'rails/commands/server'
+
+module Rails
+  class Server
+    alias :default_options_alias :default_options
+    def default_options
+      default_options_alias.merge!(:Host => '0.0.0.0')
+    end
+  end
+end

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,18 @@
+vagrant: &vagrant
+  adapter: mysql2
+  encoding: utf8
+  username: hackweek
+  password: S3cr3t
+
+development:
+  <<: *vagrant
+  database: hackweek_development
+  pool: 5
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *vagrant
+  database: hackweek_test
+  pool: 5


### PR DESCRIPTION
To enable our a little bit more complex setup (real SQL server + searchd) we need a turn-key solution for development and testing environments. (Or else we'll be forced to answer numerous questions on how to install Sphinx search in MacOS and so on.)

Vagrant seems to be an ideal tool for our cause. I've tried to make the setup as automated as possible; There is also a new section in the Readme with full step-by-step guid on how to get started (should be platform-independent).