### PR TITLE
Markdown preview

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,4 +81,7 @@ group :test do
 
   # Time travel in tests
   gem 'timecop'
+
+  # Let's add real browser testing to our features (required to test AJAX)
+  gem 'poltergeist'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       xpath (~> 2.0)
     climate_control (0.0.3)
       activesupport (>= 3.0)
+    cliver (0.3.2)
     cocaine (0.5.7)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.0)
@@ -166,6 +167,11 @@ GEM
       mime-types
     parser (2.2.0.3)
       ast (>= 1.1, < 3.0)
+    poltergeist (1.6.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      multi_json (~> 1.0)
+      websocket-driver (>= 0.2.0)
     powerpack (0.1.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -294,6 +300,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    websocket-driver (0.5.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -325,6 +334,7 @@ DEPENDENCIES
   mousetrap-rails
   mysql2
   paperclip (~> 4.1)
+  poltergeist
   pry-byebug
   pry-rails
   quiet_assets

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,21 +41,27 @@ $(function() {
 });
 
 $(function() {
-  $('.show-preview').click(
+  $('#show-preview').click(
     function() {
-      $('.markdown-source').hide();
-      $('.markdown-preview').show();
+      $('.markdown-source').removeClass('active');
+      $('.markdown-preview').addClass('active');
+
+      $('#show-source').removeClass('active');
+      $('#show-preview').addClass('active');
+
       // var text = $('.markdown-source').val();
       // $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
     });
 });
 
-$(funsction() {
-  $('.show-source').click(
+$(function() {
+  $('#show-source').click(
     function () {
-      $('.markdown-preview').hide();
-      $('.markdown-source').show();
+      $('.markdown-preview').removeClass('active');
+      $('.markdown-source').addClass('active');
 
+      $('#show-preview').removeClass('active');
+      $('#show-source').addClass('active');
       // TODO Put spinner back into .markdown-preview here
     });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,7 +43,7 @@ $(function() {
 $(function() {
   $('#show-preview').click(
     function() {
-      var text = $('#markdown-source-text').val();
+      var text = $('.markdown-source-text').val();
       $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
     });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -39,3 +39,11 @@ $(function() {
     var hash = window.location.hash;
     hash && $('ul.nav a[href="' + hash + '"]').tab('show');
 });
+
+$(function() {
+  $('.markdown-preview').click(
+    function() {
+      var text = $('.markdown-preview-source').val();
+      $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
+    });
+});

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -41,9 +41,21 @@ $(function() {
 });
 
 $(function() {
-  $('.markdown-preview').click(
+  $('.show-preview').click(
     function() {
-      var text = $('.markdown-preview-source').val();
-      $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
+      $('.markdown-source').hide();
+      $('.markdown-preview').show();
+      // var text = $('.markdown-source').val();
+      // $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
+    });
+});
+
+$(funsction() {
+  $('.show-source').click(
+    function () {
+      $('.markdown-preview').hide();
+      $('.markdown-source').show();
+
+      // TODO Put spinner back into .markdown-preview here
     });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,11 +26,11 @@ $(function() {
   });
   // navigate to a tab when the history changes
   window.addEventListener("popstate", function(e) {
-    var activeTab = $('[href=' + location.hash + ']');
+    var activeTab = $('a[href="' + location.hash + '"]');
     if (activeTab.length) {
       activeTab.tab('show');
     } else {
-      $('.nav-tabs a[href=#<%= j @today %>]').tab('show');
+      $('.nav-tabs a').first().tab('show');
     }
   });
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -43,25 +43,18 @@ $(function() {
 $(function() {
   $('#show-preview').click(
     function() {
-      $('.markdown-source').removeClass('active');
-      $('.markdown-preview').addClass('active');
-
-      $('#show-source').removeClass('active');
-      $('#show-preview').addClass('active');
-
-      // var text = $('.markdown-source').val();
-      // $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
+      var text = $('#markdown-source-text').val();
+      $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
     });
 });
 
 $(function() {
   $('#show-source').click(
-    function () {
-      $('.markdown-preview').removeClass('active');
-      $('.markdown-source').addClass('active');
-
-      $('#show-preview').removeClass('active');
-      $('#show-source').addClass('active');
-      // TODO Put spinner back into .markdown-preview here
-    });
+    setTimeout(
+      function () {
+        $('#preview-contents').addClass('hidden');
+        $('#loading-spinner').removeClass('hidden');
+      }, 200
+    )
+  );
 });

--- a/app/assets/stylesheets/hackweek.css.scss
+++ b/app/assets/stylesheets/hackweek.css.scss
@@ -47,8 +47,7 @@ footer {
     z-index: -1;
 }
 
-.markdown-preview {
-  z-index: 100;
-  position: absolute;
-  right: 15px;
+.loading-spinner {
+  text-align: center;
+  vertical-align: bottom;
 }

--- a/app/assets/stylesheets/hackweek.css.scss
+++ b/app/assets/stylesheets/hackweek.css.scss
@@ -47,7 +47,7 @@ footer {
     z-index: -1;
 }
 
-.loading-spinner {
+#loading-spinner {
   text-align: center;
   vertical-align: bottom;
 }

--- a/app/assets/stylesheets/hackweek.css.scss
+++ b/app/assets/stylesheets/hackweek.css.scss
@@ -34,15 +34,21 @@ footer {
 }
 
 .project-list-pills {
-  position: relative; 
+  position: relative;
   z-index: 1;
 }
 
 .project-list-item:before {
-    display:block; 
-    position: relative; 
-    content:""; 
-    height:70px; 
-    margin:-70px 0 0; 
+    display:block;
+    position: relative;
+    content:"";
+    height:70px;
+    margin:-70px 0 0;
     z-index: -1;
+}
+
+.markdown-preview {
+  z-index: 100;
+  position: absolute;
+  right: 15px;
 }

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -1,0 +1,9 @@
+class MarkdownController < ApplicationController
+  def preview
+    respond_to do |format|
+      format.js do
+        render
+      end
+    end
+  end
+end

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -1,8 +1,10 @@
 class MarkdownController < ApplicationController
+  skip_before_filter :authenticate_user!, only: [:preview]
   respond_to :js
 
   def preview
-    @text = 'Hello!'
-    respond_with @text
+    markdown_source = params[:source]
+    @rendered = MarkdownHelper.render markdown_source
+    respond_with @rendered
   end
 end

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -1,9 +1,8 @@
 class MarkdownController < ApplicationController
+  respond_to :js
+
   def preview
-    respond_to do |format|
-      format.js do
-        render
-      end
-    end
+    @text = 'Hello!'
+    respond_with @text
   end
 end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,2 @@
+module MarkdownHelper
+end

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,2 +1,8 @@
 module MarkdownHelper
+  def self.render markdown_source
+    renderer = Redcarpet::Render::HTML.new
+    markdown = Redcarpet::Markdown.new(renderer)
+
+    markdown.render markdown_source
+  end
 end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,3 +29,11 @@
 
     = render :partial => "layouts/scripts"
     = yield :script
+
+  .modal.fade#modal{ role: :dialog, aria_hidden: true }
+    .modal-dialog
+      .modal-content
+        .modal-header#modal-header
+        .modal-body#modal-body
+        .modal-footer
+          %button.btn.btn-default{ type: :button, data:{ dismiss: :modal }} Close

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,0 +1,1 @@
+console.log("Hello!");

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,3 +1,3 @@
-$('#modal-header').html("<h4>Markdown preview</h4>");
-$('#modal-body').html("<%=j raw @rendered %>");
-$('#modal').modal();
+$('#preview-contents').html("<%=j raw @rendered %>");
+$('#loading-spinner').addClass('hidden');
+$('#preview-contents').removeClass('hidden');

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,3 +1,3 @@
 $('#modal-header').html("<h4>Markdown preview</h4>");
-$('#modal-body').html("<%=j @text %>");
+$('#modal-body').html("<%=j raw @rendered %>");
 $('#modal').modal();

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,1 +1,3 @@
-console.log("Hello!");
+$('#modal-header').html("<h4>Markdown preview</h4>");
+$('#modal-body').html("<%=j @text %>");
+$('#modal').modal();

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -15,16 +15,19 @@
   
   .panel.panel-default
     .panel-heading
-      %ul.nav.nav-tabs
-        %li.active{ role: :presentation }
-          %a.show-source{ href: '#' } Edit
-        %li{ role: :presentation }
-          %a.show-preview{ href: '#' } Preview
+      %ul.nav.nav-pills
+        %li.active#show-source{ role: :presentation }
+          %a{ href: '#' } Edit
+        %li#show-preview{ role: :presentation }
+          %a{ href: '#' } Preview
     .panel-body
-      .form-group.markdown-source
-        = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
-      .markdown-preview
-        = fa_icon 'spinner pulse 3x', class: 'text-center'
+      .tab-content
+        .tab-pane.form-group.markdown-source.active
+          = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
+        .tab-pane.markdown-preview
+          .loading-spinner
+            = fa_icon 'spinner pulse 3x'
+          #preview-contents.hidden
 
   .form-group
     = f.label(:avatar)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -12,12 +12,19 @@
 
   .form-group
     = f.text_field :title, placeholder: 'Project title', class: 'form-control input-lg', required: 'required'
-
-  .form-group
-    %a.btn.btn-default.markdown-preview{ href: '#' }
-      = fa_icon :eye
-      Preview
-    = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg markdown-preview-source'
+  
+  .panel.panel-default
+    .panel-heading
+      %ul.nav.nav-tabs
+        %li.active{ role: :presentation }
+          %a.show-source{ href: '#' } Edit
+        %li{ role: :presentation }
+          %a.show-preview{ href: '#' } Preview
+    .panel-body
+      .form-group.markdown-source
+        = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
+      .markdown-preview
+        = fa_icon 'spinner pulse 3x', class: 'text-center'
 
   .form-group
     = f.label(:avatar)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -14,10 +14,10 @@
     = f.text_field :title, placeholder: 'Project title', class: 'form-control input-lg', required: 'required'
 
   .form-group
-    = link_to markdown_preview_path, remote: true, class: 'btn btn-default markdown-preview' do
+    %a.btn.btn-default.markdown-preview{ href: '#' }
       = fa_icon :eye
       Preview
-    = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
+    = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg markdown-preview-source'
 
   .form-group
     = f.label(:avatar)

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -17,15 +17,16 @@
     .panel-heading
       %ul.nav.nav-pills
         %li.active#show-source{ role: :presentation }
-          %a{ href: '#' } Edit
+          %a{ href: '#markdown-source', role: :tab, data: { toggle: :tab } } Edit
         %li#show-preview{ role: :presentation }
-          %a{ href: '#' } Preview
+          %a{ href: '#markdown-preview', role: :tab, data: { toggle: :tab } } Preview
     .panel-body
       .tab-content
-        .tab-pane.form-group.markdown-source.active
-          = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
-        .tab-pane.markdown-preview
-          .loading-spinner
+        #markdown-source.tab-pane.active.fade.in{ role: 'tab-pane' }
+          .form-group
+            = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg', id: 'markdown-source-text'
+        #markdown-preview.tab-pane.fade{ role: 'tab-pane' }
+          #loading-spinner
             = fa_icon 'spinner pulse 3x'
           #preview-contents.hidden
 

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -1,25 +1,27 @@
-= render :partial => 'comments/help'
-= form_for @project, :url => (@project.new_record? ? projects_path : project_path(@episode, @project)), html: { role: "form"} do |f| 
+= render partial: 'comments/help'
+= form_for @project, url: (@project.new_record? ? projects_path : project_path(@episode, @project)), html: { role: :form } do |f|
   - if @project.errors.any?
     #error_explanation
       %h2
-        = pluralize(@project.errors.count, "error")
+        = pluralize(@project.errors.count, 'error')
         prohibited this project from being saved:
-
       %ul
       - @project.errors.full_messages.each do |msg|
         %li
           = msg
-  .field
-    = f.text_field :title, :placeholder => "The projects title", :class => 'form-control input-lg', :required => "required"
-    
-  .field
-    = f.text_area :description, :rows => "20", :placeholder => "Add a detailed description of your idea. You can use markdown.", :class => 'form-control input-lg'
-  .field
+
+  .form-group
+    = f.text_field :title, placeholder: 'Project title', class: 'form-control input-lg', required: 'required'
+
+  .form-group
+    = link_to markdown_preview_path, remote: true, class: 'btn btn-default markdown-preview' do
+      = fa_icon :eye
+      Preview
+    = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg'
+
+  .form-group
     = f.label(:avatar)
     = f.file_field :avatar
-  .actions
-    %p
-      = f.submit :class => "btn btn-success pull-right"
+  = f.submit class: 'btn btn-success pull-right'
 
 

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -24,7 +24,7 @@
       .tab-content
         #markdown-source.tab-pane.active.fade.in{ role: 'tab-pane' }
           .form-group
-            = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg', id: 'markdown-source-text'
+            = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg markdown-source-text', id: 'project_description'
         #markdown-preview.tab-pane.fade{ role: 'tab-pane' }
           #loading-spinner
             = fa_icon 'spinner pulse 3x'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
-# Add repository for Sphinx search
+# Add repository with Sphinx search engine
 zypper addrepo -f 'http://download.opensuse.org/repositories/server:/search/openSUSE_13.2/server:search.repo'
+# Add repository with latest PhantomJS headless browser
+zypper addrepo -f 'http://download.opensuse.org/repositories/OBS:/Server:/2.6/openSUSE_13.2/OBS:Server:2.6.repo'
 zypper --gpg-auto-import-keys refresh
 
 # Install required packages
-zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler libxml2-devel libxslt-devel sqlite3-devel nodejs
+zypper install -y mysql mysql-devel sphinx ruby-devel rubygem-bundler libxml2-devel libxslt-devel sqlite3-devel nodejs \
+                  phantomjs
 
 # Enable MySQL service — now and on startup
 chkconfig mysql on
@@ -20,4 +23,4 @@ mysql -e "CREATE DATABASE IF NOT EXISTS hackweek_test DEFAULT CHARACTER SET utf8
 mysql -e "GRANT ALL PRIVILEGES on hackweek_test.* to hackweek@localhost identified by 'S3cr3t';"
 
 # Download english morphology dictionary
-wget 'http://sphinxsearch.com/files/dicts/en.pak' -O /vagrant/en.pak
+wget -N 'http://sphinxsearch.com/files/dicts/en.pak' -O /vagrant/en.pak

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,4 +23,4 @@ mysql -e "CREATE DATABASE IF NOT EXISTS hackweek_test DEFAULT CHARACTER SET utf8
 mysql -e "GRANT ALL PRIVILEGES on hackweek_test.* to hackweek@localhost identified by 'S3cr3t';"
 
 # Download english morphology dictionary
-wget -N 'http://sphinxsearch.com/files/dicts/en.pak' -O /vagrant/en.pak
+wget 'http://sphinxsearch.com/files/dicts/en.pak' -O /vagrant/en.pak

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Hackweek::Application.routes.draw do
 
+  get 'markdown/preview'
+
   devise_for :users
 
   resources :users do

--- a/spec/controllers/markdown_controller_spec.rb
+++ b/spec/controllers/markdown_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe MarkdownController, type: :controller do
+
+  describe "GET #preview" do
+    it "returns http success" do
+      get :preview
+      expect(response).to have_http_status(:success)
+    end
+  end
+
+end

--- a/spec/controllers/markdown_controller_spec.rb
+++ b/spec/controllers/markdown_controller_spec.rb
@@ -2,10 +2,14 @@ require 'rails_helper'
 
 RSpec.describe MarkdownController, type: :controller do
 
-  describe "GET #preview" do
-    it "returns http success" do
-      get :preview
+  describe 'GET #preview' do
+    it 'correctly assigns rendered html' do
+      source = '*italic*'
+
+      xhr :get, :preview, format: :js, source: source
+
       expect(response).to have_http_status(:success)
+      expect(assigns(:rendered)).to eq "<p><em>italic</em></p>\n"
     end
   end
 

--- a/spec/features/project_management_spec.rb
+++ b/spec/features/project_management_spec.rb
@@ -85,7 +85,7 @@ feature 'Project management' do
   scenario 'User uses markdown preview button during editing', :js do
     visit '/projects/new'
     fill_in 'project_description', with: '_italic_ **bold**'
-    click_button 'Preview'
+    click_link 'Preview'
 
     expect(page).to have_css('i', text: 'italic')
     expect(page).to have_css('b', text: 'bold')

--- a/spec/features/project_management_spec.rb
+++ b/spec/features/project_management_spec.rb
@@ -1,13 +1,18 @@
 require 'rails_helper'
 
 feature 'Project management' do
-  scenario 'User creates a new project' do
-    user = create(:user)
+
+  let(:user) {create :user}
+
+  before :each do
     sign_in user
+  end
+
+  scenario 'User creates a new project' do
     title = Faker::Lorem.sentence
     description = Faker::Lorem.paragraph
 
-    visit '/projects/new'
+    visit new_project_path
 
     fill_in 'project_title', with: title
     fill_in 'project_description', with: description
@@ -21,13 +26,12 @@ feature 'Project management' do
   end
 
   scenario 'User edits a project' do
-    user = create(:user)
     project = create(:idea, originator: user)
-    sign_in user
+
     title = Faker::Lorem.sentence
     description = Faker::Lorem.paragraph
 
-    visit "/projects/#{project.to_param}/edit"
+    visit edit_project_path(nil, project)
 
     fill_in 'project_title', with: title
     fill_in 'project_description', with: description
@@ -39,11 +43,9 @@ feature 'Project management' do
   end
 
   scenario 'User deletes a project' do
-    user = create(:user)
     project = create(:idea, originator: user)
-    sign_in user
 
-    visit "/projects/#{project.to_param}"
+    visit project_path(nil, project)
 
     expect {
       click_link "project#{project.to_param}-delete-link"
@@ -51,11 +53,9 @@ feature 'Project management' do
   end
 
   scenario 'User archives an idea' do
-    user = create(:user)
     project = create(:idea, originator: user)
-    sign_in user
 
-    visit "/projects/#{project.to_param}"
+    visit project_path(nil, project)
 
     expect {
       click_link "project#{project.to_param}-recess-link"
@@ -63,11 +63,9 @@ feature 'Project management' do
   end
 
   scenario 'User finishes a project' do
-    user = create(:user)
     project = create(:project, originator: user, users: [user])
-    sign_in user
 
-    visit "/projects/#{project.to_param}"
+    visit project_path(nil, project)
 
     expect {
       click_link "project#{project.to_param}-advance-link"
@@ -75,11 +73,9 @@ feature 'Project management' do
   end
 
   scenario 'User restarts a project' do
-    user = create(:user)
     project = create(:invention, originator: user, users: [user])
 
-    sign_in user
-    visit "/projects/#{project.to_param}"
+    visit project_path(nil, project)
     click_link "project#{project.to_param}-recess-link"
 
     project.reload

--- a/spec/features/project_management_spec.rb
+++ b/spec/features/project_management_spec.rb
@@ -87,7 +87,7 @@ feature 'Project management' do
     fill_in 'project_description', with: '_italic_ **bold**'
     click_link 'Preview'
 
-    expect(page).to have_css('i', text: 'italic')
-    expect(page).to have_css('b', text: 'bold')
+    expect(page).to have_css('em', text: 'italic')
+    expect(page).to have_css('strong', text: 'bold')
   end
 end

--- a/spec/features/project_management_spec.rb
+++ b/spec/features/project_management_spec.rb
@@ -81,4 +81,13 @@ feature 'Project management' do
     project.reload
     expect(project.aasm_state).to eq('project')
   end
+
+  scenario 'User uses markdown preview button during editing', :js do
+    visit '/projects/new'
+    fill_in 'project_description', with: '_italic_ **bold**'
+    click_button 'Preview'
+
+    expect(page).to have_css('i', text: 'italic')
+    expect(page).to have_css('b', text: 'bold')
+  end
 end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the MarkdownHelper. For example:
+#
+# describe MarkdownHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe MarkdownHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/markdown_helper_spec.rb
+++ b/spec/helpers/markdown_helper_spec.rb
@@ -11,5 +11,10 @@ require 'rails_helper'
 #   end
 # end
 RSpec.describe MarkdownHelper, type: :helper do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#render' do
+    it 'correctly renders simple tags' do
+      source = '**bold**'
+      expect(subject.render(source)).to eq "<p><strong>bold</strong></p>\n"
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,4 +1,5 @@
 require 'simplecov'
+require 'capybara/poltergeist'
 
 if ENV['TRAVIS']
   require 'coveralls'
@@ -33,6 +34,8 @@ RSpec.configure do |config|
   # mix in different behaviours to your tests based on their file location,
   # for example enabling you to call `get` and `post` in specs under `spec/controllers`.
   config.infer_spec_type_from_file_location!
+
+  Capybara.javascript_driver = :poltergeist
 
   # Setting up DB cleaning to maintain empty rows
   config.before(:suite) do

--- a/spec/views/markdown/preview.js.erb_spec.rb
+++ b/spec/views/markdown/preview.js.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "markdown/preview.html.haml", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/markdown/preview.js.erb_spec.rb
+++ b/spec/views/markdown/preview.js.erb_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe "markdown/preview.html.haml", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
-end


### PR DESCRIPTION
Closes #91

Opens previews in a modal popup window.
Works via javascript and AJAX.
Should be more or less covered by tests (and that coverage is easy to extend in case of bugs).

Currently only bound to Project description form field, but should be pretty easy to attach to other forms/fields as well.