### PR TITLE
Fix better errors

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  config.vm.network 'private_network', ip: '10.0.2.2'
+  config.vm.network :private_network, ip: '10.0.2.15'
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.
-  # config.vm.network :private_network, ip: "192.168.33.10"
+  config.vm.network 'private_network', ip: '10.0.2.2'
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -42,7 +42,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Use 1Gb of RAM for Vagrant box (otherwise bundle will go to swap)
   config.vm.provider :virtualbox do |vb|
-    vb.customize ["modifyvm", :id, "--memory", "1024"]
+    vb.customize ['modifyvm', :id, '--memory', '1024']
   end
 
   # Provision the box with a simple shell script

--- a/config/initializers/better_errors.rb
+++ b/config/initializers/better_errors.rb
@@ -1,0 +1,1 @@
+BetterErrors::Middleware.allow_ip! '10.0.2.2' if Rails.env.development?


### PR DESCRIPTION
We've been running better_errors inside a Vagrant box — and were forbidden by the default security scope from actually using the gem.

This PR fixes that, but still might require some tweaks for every user — as IP adresses Vagrant uses might change from machine to machine.