### PR TITLE
Add rack-mini-profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'spring-commands-rspec', group: [:development, :test]
 group :development, :test do
   gem 'better_errors'
 
+  gem 'rack-mini-profiler'
   gem 'pry-byebug'
   gem 'pry-rails'
   gem 'hirb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,6 +188,8 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.0)
+    rack-mini-profiler (0.9.3)
+      rack (>= 1.1.3)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.1)
@@ -342,6 +344,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   quiet_assets
+  rack-mini-profiler
   rails (~> 4.2)
   redcarpet
   rspec-rails


### PR DESCRIPTION
Add rack-mini-profiler gem (enabled in development mode only by default), so we can spot performance bottlenecks in rendering/sql queries.