### PR TITLE
Replace partials with decorator methods on project page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ gem 'cancancan'
 gem 'gravtastic'
 # for markdown rendering
 gem 'redcarpet'
+# for view presenters/decorators
+gem 'draper'
 # for token input
 gem 'selectize-rails'
 # as state machine

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,11 @@ GEM
       devise (>= 2.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    draper (2.1.0)
+      actionpack (>= 3.0)
+      activemodel (>= 3.0)
+      activesupport (>= 3.0)
+      request_store (~> 1.0)
     erubis (2.7.0)
     execjs (2.4.0)
     factory_girl (4.5.0)
@@ -219,6 +224,7 @@ GEM
     rainbow (2.0.0)
     rake (10.4.2)
     redcarpet (3.2.2)
+    request_store (1.1.0)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rest-client (1.7.3)
@@ -325,6 +331,7 @@ DEPENDENCIES
   database_cleaner
   devise
   devise_ichain_authenticatable
+  draper
   factory_girl_rails
   faker
   figaro

--- a/app/decorators/project_decorator.rb
+++ b/app/decorators/project_decorator.rb
@@ -1,0 +1,40 @@
+class ProjectDecorator < Draper::Decorator
+  delegate_all
+
+  def state_name
+    if ["idea", "invention"].include?(object.aasm_state)
+      "an #{object.aasm_state}"
+    else
+      "a #{object.aasm_state}"
+    end
+  end
+
+  def updated_at
+    "Last updated #{h.time_ago_in_words(object.updated_at)} ago."
+  end
+
+  def kudos
+    if object.kudos.length > 0
+      "Captured #{h.pluralize(object.kudos.length, "hackers heart.", "hacker hearts.")}"
+    else
+      "No love."
+    end
+  end
+
+  def grab_it_link
+    if object.users.empty?
+      "No hacker. How about you #{h.link_to('grab it!', h.join_project_path(object), :method => :post)}".html_safe
+    end
+  end
+
+  def like_button
+    dislike = "display: none;" unless object.kudos.include?(h.current_user)
+    like    = "display: none;" if object.kudos.include?(h.current_user)
+
+    dislike_opts = {:title=>'Dislike this project?', :class=> "btn btn-default btn-xs", :id => "dislike-#{object.id}", :style => "#{dislike}", :remote=>true}
+    like_opts    = {:title=>'Like this project', :class=> "btn btn-default btn-xs", :id => "like-#{object.id}", :style => "#{like}", :remote => true}
+
+    h.link_to(h.dislike_project_path(object), dislike_opts) { h.content_tag(:i, "", :class => 'fa fa-heart', :style =>  "color: #73ba25;") }.html_safe +
+    h.link_to(h.like_project_path(object), like_opts) { h.content_tag(:i, "", :class => 'fa fa-heart-o') }.html_safe
+  end
+end

--- a/app/views/projects/_list.html.haml
+++ b/app/views/projects/_list.html.haml
@@ -1,7 +1,7 @@
 -if projects
   %table.table
     %thead
-    - projects.each_with_index do |project, index|
+    - projects.decorate.each_with_index do |project, index|
       %tr
         %td{:class => "#{project.aasm_state}"}
           = render :partial => "projects/list_item", :locals => {:project => project, :index => index }

--- a/app/views/projects/_list_item.html.haml
+++ b/app/views/projects/_list_item.html.haml
@@ -5,11 +5,11 @@
 
 %p{:style=>"margin-top: -10px"}
   %small
-    = render :partial => "projects/state_name", :locals => {:project => project }
+    = project.state_name
     by
     = link_to(user_path(project.originator.id)) do
       #{project.originator.name}
-      = render :partial => "projects/like_button", :locals => {:project => project }
+      = project.like_button
 :markdown
   #{truncate(project.description, length: 140)}
 - unless project.users.empty?
@@ -19,4 +19,6 @@
         = image_tag(user.gravatar_url(:size => "24"), :class => "img-thumbnail", :title => "#{user.name}", :alt => user.name)
 %span.help-block
   %small
-    = render :partial => "projects/info", :locals => {:project => project }
+    = project.updated_at
+    = project.kudos
+    = project.grab_it_link

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -41,7 +41,7 @@
             .col-sm-12
               %table.table#project_table
                 %thead
-                - @projects.each_with_index do |project, index|
+                - @projects.decorate.each_with_index do |project, index|
                   %tr
                     %td{:class => "#{project.aasm_state}"}
                       = render :partial => "projects/list_item", :locals => {:project => project, :index => index }

--- a/app/views/search/result.html.haml
+++ b/app/views/search/result.html.haml
@@ -18,7 +18,7 @@
         - unless @projects.empty?
           %table.table#project_table
             %thead
-            - @projects.each_with_index do |project, index|
+            - @projects.decorate.each_with_index do |project, index|
               %tr
                 %td{:class => "#{project.aasm_state}"}
                   = render :partial => "projects/list_item", :locals => {:project => project, :index => index }


### PR DESCRIPTION
Rendering many / nested HAML partials is taking ~ 40-60ms per project/list_item partial in development mode on a warmed up page, using last weeks production data. This can be a problem when there are many projects displayed on a page.

This patch introduces the draper gem, which provides a framework for 'decorators' - a glue code between views and models, somewhat similar to helpers.

It then duplicates some partials code into the projects_decorator methods.

Finally, it replaces partial rendering in the 'projects/list_item' with these methods and fixes the partial's callees to decorate project objects.

The list_item partial now renders in around 15ms, bringing down the page load time to ~45% (from 1800ms to 950ms for index page with 100 projects) in development mode. Combined with #133, the partial rendering time is reduced even further, to around 5ms.

Not sure if using decorators doesn't go 'against the grain' of the hackweek tool, as it seems to favor the partials approach, though. Also, impact on production performance has not been tested. This is why the patch converts only a few project related partial call sites to using a decorator method.