### PR TITLE
Ignore NotFound error in hoptoad

### DIFF
--- a/config/initializers/hoptoad.rb
+++ b/config/initializers/hoptoad.rb
@@ -8,10 +8,10 @@ HoptoadNotifier.configure do |config|
     config.development_environments = "development test"
   end
 
-  config.ignore_only = %w{ 
-  Some::ExceptionName
+  config.ignore_only = %w{
+    ActiveRecord::RecordNotFound
   }
- 
+
   config.ignore_by_filter do |exception_data|
     ret=false
     if exception_data[:error_class] == "ActionController::RoutingError" 


### PR DESCRIPTION
Do not report ActiveRecord::RecordNotFound to hoptoad, so that the
hackweek mailing list does not get spammed by exception reports caused
by users mistyping URLs.