### PR TITLE
Resolve User(originator) kudos bug

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -12,7 +12,7 @@ class ProjectsController < ApplicationController
   # GET /projects
   # GET /projects.rss
   def index
-    @projects = Project.current(@episode).active.includes(:episode_project_associations, :originator, :users, :kudos).
+    @projects = Project.current(@episode).active.includes(:episode_project_associations, :originator, :users).
         order('episodes_projects.created_at DESC').references(:episodes_projects).page(params[:page]).per(params[:page_size])
     @newest = @projects.first(10)
     respond_to do |format|

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -112,6 +112,9 @@ class Project < ActiveRecord::Base
   end
 
   def like! user
+    if self.kudos.include? user
+      return
+    end
     self.kudos << user
     self.save!
 

--- a/spec/features/collaboration_spec.rb
+++ b/spec/features/collaboration_spec.rb
@@ -52,4 +52,18 @@ feature 'Collaboration' do
     }.to change(Project.liked, :count).by(-1)
     expect(page).not_to have_css("dislike-#{project.id}")
   end
+
+  scenario 'User likes a project multiple times' do
+    user = create(:user)
+    project = create(:idea)
+    sign_in user
+
+    visit project_path(nil, project)
+    click_link "like-#{project.id}"
+
+    expect {
+      find("#like-#{project.id}", visible: false).click
+    }.to change(Project.liked, :count).by(0)
+    expect(page).not_to have_css("like-#{project.id}")
+  end
 end


### PR DESCRIPTION
User(originator) wasnt able to become project's kudos element because of table join error.

Closes #193 

There was an error in left outer join during includes(args), by which originator wasn't included in his project's kudos.
So, he can like his project multiple times upon refresh