### PR TITLE
Change user flow for replying to a comment

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -42,22 +42,23 @@ $(function() {
 });
 
 $(function() {
-  $('#show-preview').click(
+  $('form .show-preview').click(
     function() {
-      var text = $('.markdown-source-text').val();
-      $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text));
+      var text = $(this).closest('form').find('textarea').val();
+      form_parent = $(this).closest('form').parent().attr('id');
+      $.ajax('/markdown/preview.js?source=' + encodeURIComponent(text) + '&form_parent=' + form_parent);
     });
 });
 
 $(function() {
-  $('#show-source').click(
+  $('form .show-source').click(function(){
     setTimeout(
       function () {
         $('#preview-contents').addClass('hidden');
         $('#loading-spinner').removeClass('hidden');
       }, 200
     )
-  );
+  });
 });
 
 $(function() {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -61,15 +61,6 @@ $(function() {
   });
 });
 
-$(function() {
-  $('.reply_modal_trigger').click(
-    function() {
-      action_id = $(this).data('parent');
-      $('#replyModal form').attr('action', '/comments/'+ action_id +'/comments')
-    }
-  );
-});
-
 $(function(){
   var emojis = [
     "smile", "iphone", "girl", "smiley", "heart", "kiss", "copyright", "coffee",

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -60,6 +60,15 @@ $(function() {
   );
 });
 
+$(function() {
+  $('.reply_modal_trigger').click(
+    function() {
+      action_id = $(this).data('parent');
+      $('#replyModal form').attr('action', '/comments/'+ action_id +'/comments')
+    }
+  );
+});
+
 $(function(){
   var emojis = [
     "smile", "iphone", "girl", "smiley", "heart", "kiss", "copyright", "coffee",
@@ -100,5 +109,5 @@ function textcover(txtarea, newtxt) {
         $(txtarea).val().substring(txtarea.selectionStart,txtarea.selectionEnd)+
         newtxt +
         $(txtarea).val().substring(txtarea.selectionEnd)
-   );  
+   );
 }

--- a/app/assets/stylesheets/hackweek.scss
+++ b/app/assets/stylesheets/hackweek.scss
@@ -23,14 +23,23 @@ h4.project-list-item img {
   background-color:rgba(246,246,246,0.7);
 }
 
-img[alt="add-emoji"] { 
-  max-width: 20px; 
+img[alt="add-emoji"] {
+  max-width: 20px;
   height: auto;
 }
 
 .comment-form-heading, .panel.panel-default > .panel-heading{
   display: flex;
   justify-content: space-between;
+}
+
+#replyModal{
+  h2{
+    text-align: center;
+  }
+  p:last-child{
+    padding-bottom: 1.5rem;
+  }
 }
 
 footer {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -32,7 +32,6 @@ class CommentsController < ApplicationController
       format.html
       format.js
     end
-
   end
 
   protected

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -8,7 +8,7 @@
       = link_to user_path(comment.commenter) do
         = comment.commenter.name
       |
-      = link_to 'Reply', new_comment_comment_path( comment )
+      = link_to('Reply', reply_modal_path(comment) ,class: 'reply_modal_trigger', remote: :true, data: { toggle: 'modal', target: '#replyModal', parent: "#{comment.id}" })
     %p
       :markdown
         #{ emojify comment.text }

--- a/app/views/comments/_comment.html.haml
+++ b/app/views/comments/_comment.html.haml
@@ -8,7 +8,7 @@
       = link_to user_path(comment.commenter) do
         = comment.commenter.name
       |
-      = link_to('Reply', reply_modal_path(comment) ,class: 'reply_modal_trigger', remote: :true, data: { toggle: 'modal', target: '#replyModal', parent: "#{comment.id}" })
+      = link_to('Reply', reply_modal_path(comment) ,class: 'reply_modal_trigger', remote: :true, data: { toggle: 'modal', target: '#replyModal' })
     %p
       :markdown
         #{ emojify comment.text }

--- a/app/views/comments/_form.html.haml
+++ b/app/views/comments/_form.html.haml
@@ -4,20 +4,20 @@
   %p
     .comment-form-heading
       %ul.nav.nav-tabs
-        %li.active#show-source{ role: :presentation }
-          %a{ href: '#markdown-source', role: :tab, data: { toggle: :tab } } Edit
-        %li#show-preview{ role: :presentation }
-          %a{ href: '#markdown-preview', role: :tab, data: { toggle: :tab } } Preview
+        %li.active.show-source{ role: :presentation }
+          %a{ href: "#markdown-source#{id}", role: :tab, data: { toggle: :tab } } Edit
+        %li.show-preview{ role: :presentation }
+          %a{ href: "#markdown-preview#{id}", role: :tab, data: { toggle: :tab } } Preview
       .btnbar
         = render 'shared/editor_buttons'
     .comment-form-body
       .tab-content
-        #markdown-source.tab-pane.active.fade.in{ role: 'tab-pane' }
+        .tab-pane.active.fade.in{ role: 'tab-pane', id: "markdown-source#{id}" }
           = f.text_area :text, :placeholder => "Your comment. You can use markdown.", :class => 'form-control input-lg markdown-source-text', :required => "required"
-        #markdown-preview.tab-pane.fade{ role: 'tab-pane' }
-          #loading-spinner
+        .tab-pane.fade{ role: 'tab-pane', id: "markdown-preview#{id}" }
+          .loading-spinner
             = fa_icon 'spinner pulse 3x'
-          #preview-contents.hidden
+          .preview-contents.hidden
 
   %p
     = button_tag(type: 'submit', class: "btn btn-success pull-right") do

--- a/app/views/comments/_reply_modal.html.haml
+++ b/app/views/comments/_reply_modal.html.haml
@@ -1,0 +1,13 @@
+.modal.fade{id: "replyModal","aria-labelledby" => "replyModalLabel", role: "dialog", tabindex: "-1"}
+  .modal-dialog{role: "document"}
+    .modal-content
+      .modal-header
+        %button.close{'aria-label' => 'Close', 'data-dismiss' => 'modal', type: 'button'}
+          %span{'aria-hidden' => 'true'} ×
+        %h2#replyModalLabel.modal-title Reply to :
+      .modal-body
+        %h4#parent_comment_content
+          Loading ...
+        %hr
+        .replyform
+          = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project}

--- a/app/views/comments/_reply_modal.html.haml
+++ b/app/views/comments/_reply_modal.html.haml
@@ -9,5 +9,5 @@
         %h4#parent_comment_content
           Loading ...
         %hr
-        .replyform
-          = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project}
+        #replyform
+          = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project, id: rand(36**10).to_s(36).upcase[0,5] }

--- a/app/views/comments/reply_modal.js.erb
+++ b/app/views/comments/reply_modal.js.erb
@@ -1,4 +1,5 @@
 $('#replyModal form').attr('action', '/comments/<%= @comment.id %>/comments');
 $('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+$('meta[name="csrf-token"]').attr('content', '<%=form_authenticity_token%>');
 $('#replyModalLabel').html('Reply to : <%= @comment.commenter.name %>');
 $('#parent_comment_content').html('<%= j raw @rendered.html_safe %>');

--- a/app/views/comments/reply_modal.js.erb
+++ b/app/views/comments/reply_modal.js.erb
@@ -1,0 +1,2 @@
+$('#replyModalLabel').html('Reply to : <%= @comment.commenter.name %>');
+$('#parent_comment_content').html('<%= j raw @rendered.html_safe %>');

--- a/app/views/comments/reply_modal.js.erb
+++ b/app/views/comments/reply_modal.js.erb
@@ -1,2 +1,4 @@
+$('#replyModal form').attr('action', '/comments/<%= @comment.id %>/comments');
+$('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
 $('#replyModalLabel').html('Reply to : <%= @comment.commenter.name %>');
 $('#parent_comment_content').html('<%= j raw @rendered.html_safe %>');

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -2,3 +2,4 @@ $('#<%= params[:form_parent]%> .preview-contents').html("<%=j raw @rendered %>")
 $('#<%= params[:form_parent]%> .loading-spinner').addClass('hidden');
 $('#<%= params[:form_parent]%> .preview-contents').removeClass('hidden');
 $('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+$('meta[name="csrf-token"]').attr('content', '<%=form_authenticity_token%>');

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,4 +1,13 @@
-$('#preview-contents').html("<%=j raw @rendered %>");
-$('#loading-spinner').addClass('hidden');
-$('#preview-contents').removeClass('hidden');
+// ele = $('li[data-form-type="<%=params[:form_type]%>"]').closest('form');
+// console.log(ele.find('#preview-contents'));
+// ele.find('#preview-contents').html("<%=j raw @rendered %>");
+// ele.find('#loading-spinner').addClass('hidden');
+// ele.find('#preview-contents').removeClass('hidden');
+// $('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+// form_markdown_element = $('<%= j params[:form_markdown_element]%>')[0];
+// console.log(form_markdown_element);
+// console.log($('#<%= params[:form_parent]%> .preview-contents'));
+$('#<%= params[:form_parent]%> .preview-contents').html("<%=j raw @rendered %>");
+$('#<%= params[:form_parent]%> .loading-spinner').addClass('hidden');
+$('#<%= params[:form_parent]%> .preview-contents').removeClass('hidden');
 $('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');

--- a/app/views/markdown/preview.js.erb
+++ b/app/views/markdown/preview.js.erb
@@ -1,12 +1,3 @@
-// ele = $('li[data-form-type="<%=params[:form_type]%>"]').closest('form');
-// console.log(ele.find('#preview-contents'));
-// ele.find('#preview-contents').html("<%=j raw @rendered %>");
-// ele.find('#loading-spinner').addClass('hidden');
-// ele.find('#preview-contents').removeClass('hidden');
-// $('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
-// form_markdown_element = $('<%= j params[:form_markdown_element]%>')[0];
-// console.log(form_markdown_element);
-// console.log($('#<%= params[:form_parent]%> .preview-contents'));
 $('#<%= params[:form_parent]%> .preview-contents').html("<%=j raw @rendered %>");
 $('#<%= params[:form_parent]%> .loading-spinner').addClass('hidden');
 $('#<%= params[:form_parent]%> .preview-contents').removeClass('hidden');

--- a/app/views/projects/_form.html.haml
+++ b/app/views/projects/_form.html.haml
@@ -1,41 +1,42 @@
 = render partial: 'comments/help'
-= form_for @project, url: (@project.new_record? ? projects_path : project_path(@episode, @project)), html: { role: :form } do |f|
-  - if @project.errors.any?
-    .alert.alert-warning
-      %strong
-        = pluralize(@project.errors.count, 'error')
-        prohibited this project from being saved:
-      %ul
-      - @project.errors.full_messages.each do |msg|
-        %li
-          = msg
+#project_form
+  = form_for @project, url: (@project.new_record? ? projects_path : project_path(@episode, @project)), html: { role: :form } do |f|
+    - if @project.errors.any?
+      .alert.alert-warning
+        %strong
+          = pluralize(@project.errors.count, 'error')
+          prohibited this project from being saved:
+        %ul
+        - @project.errors.full_messages.each do |msg|
+          %li
+            = msg
 
-  .form-group
-    = f.text_field :title, placeholder: 'Project title', class: 'form-control input-lg', required: 'required'
+    .form-group
+      = f.text_field :title, placeholder: 'Project title', class: 'form-control input-lg', required: 'required'
 
-  .panel.panel-default
-    .panel-heading
-      %ul.nav.nav-pills
-        %li.active#show-source{ role: :presentation }
-          %a{ href: '#markdown-source', role: :tab, data: { toggle: :tab } } Edit
-        %li#show-preview{ role: :presentation }
-          %a{ href: '#markdown-preview', role: :tab, data: { toggle: :tab } } Preview
-      .btnbar
-        = render 'shared/editor_buttons'
-    .panel-body
-      .tab-content
-        #markdown-source.tab-pane.active.fade.in{ role: 'tab-pane' }
-          .form-group
-            = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg markdown-source-text', id: 'project_description'
-        #markdown-preview.tab-pane.fade{ role: 'tab-pane' }
-          #loading-spinner
-            = fa_icon 'spinner pulse 3x'
-          #preview-contents.hidden
+    .panel.panel-default
+      .panel-heading
+        %ul.nav.nav-pills
+          %li.active.show-source{ role: :presentation }
+            %a{ href: '#markdown-source', role: :tab, data: { toggle: :tab } } Edit
+          %li.show-preview{ role: :presentation }
+            %a{ href: '#markdown-preview', role: :tab, data: { toggle: :tab } } Preview
+        .btnbar
+          = render 'shared/editor_buttons'
+      .panel-body
+        .tab-content
+          #markdown-source.tab-pane.active.fade.in{ role: 'tab-pane' }
+            .form-group
+              = f.text_area :description, rows: 20, placeholder: 'Detailed description of your idea. You can use **markdown**.', class: 'form-control input-lg markdown-source-text', id: 'project_description'
+          #markdown-preview.tab-pane.fade{ role: 'tab-pane' }
+            .loading-spinner
+              = fa_icon 'spinner pulse 3x'
+            .preview-contents.hidden
 
-  .form-group
-    = f.label(:avatar)
-    = f.file_field :avatar
-  = f.submit class: 'btn btn-success pull-right'
+    .form-group
+      = f.label(:avatar)
+      = f.file_field :avatar
+    = f.submit class: 'btn btn-success pull-right'
 
   :javascript
     $('textarea').atwho({at:"@", 'data':#{raw @username_array}});

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -99,14 +99,14 @@
           %li
             = render :partial => "updates/show", :locals => { :update => update }
 .row
-  .col-sm-12
+  .col-sm-12#comments_section
     %h4
       Comments
     %ul.media-list
       = render :partial => 'comments/comment', :collection => @project.comments
     %p
       - if current_user
-        = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project }
+        = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project, id: rand(36**10).to_s(36).upcase[0,5] }
 
 = render partial: 'comments/reply_modal'
 

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -108,6 +108,8 @@
       - if current_user
         = render partial: 'comments/form', locals: { comment: @new_comment, parent: @project }
 
+= render partial: 'comments/reply_modal'
+
 - content_for :script do
   :javascript
     Mousetrap.bind('j', function() { $('#previous_link').click(); });

--- a/app/views/shared/_editor_buttons.html.haml
+++ b/app/views/shared/_editor_buttons.html.haml
@@ -1,10 +1,11 @@
-%a.btn.btn-default{onclick: "$('textarea').eq(0).val($('textarea').eq(0).val() + ' @').click();"}
+- @textarea = "$(this).closest('form').find('textarea')"
+%a.btn.btn-default{onclick: "#{@textarea}.val(#{@textarea}.val() + ' @').click();"}
   %i.fa.fa-at
-%a.btn.btn-default{onclick: "$('textarea').eq(0).val($('textarea').eq(0).val() + ' :').click();"}
+%a.btn.btn-default{onclick: "#{@textarea}.val(#{@textarea}.val() + ' :').click();"}
   %i.fa.fa-smile-o
-%a.btn.btn-default{onclick: "$('textarea').eq(0).val($('textarea').eq(0).val() + ' [text](link-here)').click();"}
+%a.btn.btn-default{onclick: "#{@textarea}.val(#{@textarea}.val() + ' [text](link-here)').click();"}
   %i.fa.fa-link
-%a.btn.btn-default{onclick: "textcover($('textarea')[0], '_')"}
+%a.btn.btn-default{onclick: "textcover(#{@textarea}[0], '_')"}
   %i.fa.fa-italic
-%a.btn.btn-default{onclick: "textcover($('textarea')[0], '**')"}
+%a.btn.btn-default{onclick: "textcover(#{@textarea}[0], '**')"}
   %i.fa.fa-bold

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,8 @@ Hackweek::Application.routes.draw do
     end
   end
 
+  get '/reply/:id', to: "comments#reply_modal", as: 'reply_modal'
+
   resources :comments do
     resources :comments
   end

--- a/spec/features/project_management_spec.rb
+++ b/spec/features/project_management_spec.rb
@@ -102,4 +102,23 @@ feature 'Project management' do
     expect(page).to have_css('a[href$="/users/user"]')
     expect(page).to have_css('img[alt="add-emoji"]')
   end
+
+  scenario 'User wants to reply a comment', :js do
+    project = create(:idea, :with_comments, originator: user)
+    reply_text = Faker::Lorem.sentence
+
+    visit project_path(nil, project)
+    first_comment = project.comments.first
+    click_link 'Reply', match: :first
+
+    expect(page).to have_text first_comment.text
+    expect(page).to have_css("#replyModal.modal.in")
+
+    @modal = find '.modal.fade.in'
+    @modal.find("textarea[id$='comment_text']").set reply_text
+
+    expect {
+      @modal.find('button[name="button"]').click
+    }.to change(first_comment.comments, :count).by(1)
+  end
 end


### PR DESCRIPTION
Now, for replying to a comment,
- Instead of directing the user to a different page(comment#new), a reply modal is opened for the user to write the reply on the same page(project#show).

Inspired from _Twitter_

![peek 2018-06-02 23-27](https://user-images.githubusercontent.com/13421233/40879458-ab12a26e-66bd-11e8-97ab-048c87ab304e.gif)


