### PR TITLE
Prevent users from joining a project twice

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -119,8 +119,13 @@ class ProjectsController < ApplicationController
       redirect_to project, error: "You can't join this project as it's finished."
     end
 
-    @project.join! current_user
-    redirect_to project_path(@episode, @project), notice: "Welcome to the project #{current_user.name}!"
+    if @project.join! current_user
+      message = "Welcome to the project #{current_user.name}!"
+    else
+      message = 'You already joined this project'
+    end
+
+    redirect_to project_path(@episode, @project), notice: message
   end
 
   # PUT /projects/1/leave

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -85,6 +85,8 @@ class Project < ActiveRecord::Base
   end
 
   def join! user
+    return if self.users.include?(user)
+
     if self.users.empty?
       self.advance!
       type = 'started'

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,8 +1,10 @@
 require 'rails_helper'
 
 describe ProjectsController do
+  let(:admin) { create(:admin) }
+
   before :each do
-    sign_in create(:admin)
+    sign_in admin
   end
 
   describe 'GET index' do
@@ -173,17 +175,29 @@ describe ProjectsController do
   end
 
   describe 'POST join_project' do
+    let(:project) { create(:idea) }
+
     it 'ads an user to the project' do
-      project = create(:idea)
       expect {
           post :join, id:project.id
       }.to change(project.users, :count).by(1)
     end
 
     it 'redirects to the project' do
-      project = create(:idea)
       post :join, id:project.id
       expect(response).to redirect_to(project)
+    end
+
+    context 'when the user already joined' do
+      before do
+        project.join!(admin)
+      end
+
+      it 'does not add the user again' do
+        expect {
+            post :join, id:project.id
+        }.not_to change(project.users, :count)
+      end
     end
   end
 


### PR DESCRIPTION
Previously we did not check whether a user already joined a project
before adding him. So it was possible to join a project multiple times.

Fixes #94