### PR TITLE
Fix repository url to deploy with mina

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -11,7 +11,7 @@ set :user, 'root'
 # Path to deploy into
 set :deploy_to, '/srv/www/vhosts/suse.com/hackweek'
 # Git repo to clone from
-set :repository, 'https://github.com/SUSE/hackweek.git'
+set :repository, 'git://github.com/SUSE/hackweek.git'
 # Branch name to deploy
 set :branch, 'master'
 


### PR DESCRIPTION
Using `https` as the prefix of the repository url throw an `error:1407742E:SSL` error. Switching to `git` fixed it.

Co-authored-by: Henne Vogelsang <hvogel@opensuse.org>