### PR TITLE
Hide comment style bar in preview mode

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -137,3 +137,7 @@ function textcover(txtarea, newtxt) {
    );
 }
 
+$(document).on('click', '.show-preview, .show-source', function (e) {
+  $(this).parent().next('.btnbar').toggle();
+})
+


### PR DESCRIPTION
Every comment field has a couple of style options, like adding emojis
and links.
The events that get triggered by pressing these buttons are attached
to the comment's textfield and break when the field is gone, eg. when
in preview mode.
Hiding these buttons in preview mode solves the problem. Also these
buttons are not useful for the preview anyway.

![image](https://user-images.githubusercontent.com/968949/41822693-0d55f2ae-77f4-11e8-97fd-8af14a9d2e35.png)
