### PR TITLE
Change the way we do logging in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,8 @@ gem 'web-console', '~> 2.0', group: :development
 gem 'mina', '~> 0.3'
 # as the app server
 gem 'puma', '~> 3.11'
+# as the log formater
+gem 'lograge'
 
 group :test do
   # for cleaning the test DB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,6 +161,11 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    lograge (0.10.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -247,6 +252,8 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redcarpet (3.4.0)
+    request_store (1.4.1)
+      rack (>= 1.4)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
@@ -373,6 +380,7 @@ DEPENDENCIES
   jquery-rails
   jquery-ui-rails
   kaminari
+  lograge
   mina (~> 0.3)
   mousetrap-rails
   mysql2 (= 0.4.10)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Hackweek::Application.configure do
   config.log_level = :info
 
   # Prepend all log lines with the following tags.
-  # config.log_tags = [ :subdomain, :uuid ]
+  config.log_tags = [ :uuid ]
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
@@ -77,4 +77,16 @@ Hackweek::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  # Use lograge to show the logs in one line
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    exceptions = ['controller', 'action', 'format', 'id']
+    {
+      params: event.payload[:params].except(*exceptions),
+      host:   event.payload[:headers].env['REMOTE_ADDR'],
+      time:   event.time,
+      user:   User.current.try(:login)
+    }
+  end
 end


### PR DESCRIPTION
We now use the gem lograge to show one line per request instead of
multiple lines

Co-authored-by: David Kang <dkang@suse.com>
Co-authored-by: Moises Deniz Aleman <mdeniz@suse.com>