### PR TITLE
Remove User.name/email updating

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -46,7 +46,7 @@ class UsersController < ApplicationController
 
   private
     def user_params
-      params.require(:user).permit(:email, :name, :uid, :location)
+      params.require(:user).permit(:location)
     end
 
     def keyword_params

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -16,12 +16,6 @@
             %li
               = msg
       .field
-        = f.label :name
-        = f.text_field :name, :placeholder => "Name"
-      .field
-        = f.label :email
-        = f.text_field :email, :placeholder => "Email", :required => "required"
-      .field
         = f.label :location
         = f.text_field :location, :placeholder => "Location"
       .actions

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -24,11 +24,9 @@ describe UsersController do
   describe 'POST update' do
     it 'updates the user' do
       patch :update, id: user.id, user: {
-        location: 'space', name: 'John Doe', email: 'john@space.org' }
+        location: 'space' }
       expect(response).to redirect_to(user_path(user.reload))
       expect(user.location).to eq('space')
-      expect(user.name).to eq('John Doe')
-      expect(user.email).to eq('john@space.org')
     end
   end
 


### PR DESCRIPTION
We are behind a login proxy, user management is not happening
in our app.

Fixes #291