### PR TITLE
Fixes two sources of InvalidAuthenticityToken exceptions

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -105,29 +105,26 @@ class ProjectsController < ApplicationController
 
   # PUT /projects/1/join
   def join
-    # FIXME: This is a validation
-    if @project.aasm_state == 'invention'
-      redirect_to project, error: "You can't join this project as it's finished."
+    respond_to do |format|
+      if @project.join!(current_user)
+        format.js { flash['success'] = "Welcome to the project #{current_user.name}." }
+      else
+        format.js { flash['error'] = "#{@project.errors.full_messages.to_sentence}" }
+      end
     end
-
-    if @project.join! current_user
-      message = "Welcome to the project #{current_user.name}!"
-    else
-      message = 'You already joined this project'
-    end
-
-    redirect_to project_path(@episode, @project), notice: message
+    flash.discard
   end
 
   # PUT /projects/1/leave
   def leave
-    # FIXME: This is a validation
-    if @project.aasm_state == 'invention'
-      redirect_to @project, error: "You can't leave this project as it's finished."
+    respond_to do |format|
+      if @project.leave!(current_user)
+        format.js { flash['success'] = "Sorry to see you go #{current_user.name}." }
+      else
+        format.js { flash['error'] = "#{@project.errors.full_messages.to_sentence}" }
+      end
     end
-
-    @project.leave! current_user
-    redirect_to project_path(@episode, @project), notice: "Goodbye #{current_user.name}..."
+    flash.discard
   end
 
   # PUT /projects/1/like

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -6,7 +6,6 @@ class ProjectsController < ApplicationController
   skip_before_filter :authenticate_user!, only: [ :index, :show, :archived, :finished, :newest, :popular, :biggest, :random ]
   skip_before_filter :store_location, only: [:join, :leave, :like, :dislike, :add_keyword, :delete_keyword ]
   skip_before_action :verify_authenticity_token, only: [:add_keyword, :delete_keyword ]
-  skip_load_and_authorize_resource only: :old_archived
   before_action :load_episode
   before_action :username_array, only: [:new, :edit, :show]
   autocomplete :project, :title
@@ -54,17 +53,6 @@ class ProjectsController < ApplicationController
     @previous_project = @project.previous(@episode)
     @next_project = @project.next(@episode)
     @new_comment = Comment.new
-  end
-
-  # GET /archive/projects/:id
-  def old_archived
-    begin
-      @project = Project.find_by!(title: params[:id])
-      redirect_to @project
-    rescue ActiveRecord::RecordNotFound
-      flash[:notice] = "Can't find project with title #{params[:id]}"
-      redirect_to action: :archived
-    end
   end
 
   # GET /projects/new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,9 +4,9 @@ module ApplicationHelper
     when 'success'
       'alert-success'
     when 'error'
-      'alert-error'
+      'alert-danger'
     when 'alert'
-      'alert-block'
+      'alert-warning'
     when 'notice'
       'alert-info'
     else

--- a/app/views/announcements/_announcement_toggle.js.erb
+++ b/app/views/announcements/_announcement_toggle.js.erb
@@ -1,1 +1,3 @@
+$('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+$('meta[name="csrf-token"]').attr('content','<%= form_authenticity_token %>');
 $("#announcement-<%= @announcement.id %>").toggle();

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -22,7 +22,8 @@
       %div#loader
       #content
         - if flash
-          = render partial: "layouts/alert", flash: flash
+          #flash
+            = render partial: "layouts/alert", flash: flash
         - if @news
           = render partial: "layouts/news"
         = yield

--- a/app/views/projects/_hackers.html.haml
+++ b/app/views/projects/_hackers.html.haml
@@ -1,0 +1,3 @@
+- @project.users.each do |user|
+  = link_to(user_path(user)) do
+    = image_tag user.gravatar_url(:size => "64"), alt: user.name, title: user.name, class: "img-thumbnail", id: "user#{user.id}-gravatar"

--- a/app/views/projects/_membership_buttons.html.haml
+++ b/app/views/projects/_membership_buttons.html.haml
@@ -1,0 +1,8 @@
+- joined = @project.joined(current_user) ? 'hidden': ''
+= link_to(join_project_path(@episode, @project), :method => :post, :class => "btn btn-success #{joined}", remote: true) do
+  %i.fa.fa-plus
+  Join this project
+- joined = @project.joined(current_user) ? '': 'hidden'
+= link_to(leave_project_path(@episode, @project), :method => :post, :class => "btn btn-warning #{joined}", remote: true) do
+  %i.fa.fa-minus
+  Leave this project

--- a/app/views/projects/join.js.erb
+++ b/app/views/projects/join.js.erb
@@ -1,0 +1,5 @@
+$('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+$('meta[name="csrf-token"]').attr('content','<%= form_authenticity_token %>');
+$('#flash').html("<%= escape_javascript render partial: "layouts/alert", flash: flash %>");
+$('#hackers').html("<%= escape_javascript render partial: 'hackers' %>");
+$('#membership_buttons').html("<%= escape_javascript render partial: 'membership_buttons' %>");

--- a/app/views/projects/leave.js.erb
+++ b/app/views/projects/leave.js.erb
@@ -1,0 +1,5 @@
+$('input[name="authenticity_token"]').val('<%= form_authenticity_token %>');
+$('meta[name="csrf-token"]').attr('content','<%= form_authenticity_token %>');
+$('#flash').html("<%= escape_javascript render partial: "layouts/alert", flash: flash %>");
+$('#hackers').html("<%= escape_javascript render partial: 'hackers' %>");
+$('#membership_buttons').html("<%= escape_javascript render partial: 'membership_buttons' %>");

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -45,19 +45,10 @@
             No
           Hackers:
         .well.well-sm#hackers
-          - @project.users.each do |user|
-            = link_to(user_path(user)) do
-              = image_tag user.gravatar_url(:size => "64"), alt: user.name, title: user.name, class: "img-thumbnail", id: "user#{user.id}-gravatar"
+          = render partial: 'hackers'
         - unless @project.aasm_state == "invention"
-          %p.pull-right
-            - if @project.users.empty? or !@project.users.include? current_user
-              = link_to(join_project_path(@episode, @project), :method => :post, :class => "btn btn-success") do
-                %i.fa.fa-plus
-                Join this project
-            - if @project.users.include? current_user
-              = link_to(leave_project_path(@episode, @project), :method => :post, :class => "btn btn-warning") do
-                %i.fa.fa-minus
-                Leave this project
+          %p#membership_buttons.pull-right
+            = render partial: 'membership_buttons'
           .clearfix
     .row
       .col-sm-12

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,9 +14,6 @@ Hackweek::Application.routes.draw do
     end
   end
 
-  # compat routes
-  get 'archive/projects/:id', to: "projects#old_archived"
-
   scope '(:episode)' do
     resources :projects do
       collection do

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -171,13 +171,8 @@ describe ProjectsController do
 
     it 'ads an user to the project' do
       expect {
-          post :join, id:project.id
+          post :join, id:project.id, format: 'js'
       }.to change(project.users, :count).by(1)
-    end
-
-    it 'redirects to the project' do
-      post :join, id:project.id
-      expect(response).to redirect_to(project)
     end
 
     context 'when the user already joined' do
@@ -187,7 +182,7 @@ describe ProjectsController do
 
       it 'does not add the user again' do
         expect {
-            post :join, id:project.id
+            post :join, id:project.id, format: 'js'
         }.not_to change(project.users, :count)
       end
     end
@@ -196,16 +191,10 @@ describe ProjectsController do
   describe 'GET leave_project' do
     it 'deletes an user from the project' do
       project = create(:idea)
-      post :join, id:project.id
+      project.join!(admin)
       expect {
-          post :leave, id:project.id
+          post :leave, id:project.id, format: 'js'
       }.to change(project.users, :count).by(-1)
-    end
-
-    it 'redirects to the project' do
-      project = create(:project)
-      post :leave, id:project.id
-      expect(response).to redirect_to(project)
     end
   end
 

--- a/spec/features/collaboration_spec.rb
+++ b/spec/features/collaboration_spec.rb
@@ -1,21 +1,19 @@
 require 'rails_helper'
 
 feature 'Collaboration' do
-  scenario 'User joins a project' do
+  scenario 'User joins a project', :js do
     user = create(:user)
     project = create(:idea)
     sign_in user
 
     visit project_path(nil, project)
 
-    expect {
-      click_link 'Join this project'
-    }.to change(Project.populated, :count).by(1)
+    click_link 'Join this project'
     expect(page).to have_css("#user#{user.id}-gravatar")
-    expect(page).to have_text("Welcome to the project #{user.name}!")
+    expect(page).to have_text("Welcome to the project #{user.name}.")
   end
 
-  scenario 'User leaves a project' do
+  scenario 'User leaves a project', :js do
     user = create(:user)
     project = create(:project, users: [user])
     sign_in user
@@ -24,6 +22,7 @@ feature 'Collaboration' do
     click_link 'Leave this project'
 
     expect(page).not_to have_css("#user#{user.id}-gravatar")
+    expect(page).to have_text("Sorry to see you go #{user.name}.")
   end
 
   scenario 'User likes a project' do

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -133,4 +133,25 @@ describe Project do
       expect(project.similar_projects).to include(project2)
     end
   end
+
+  describe '.joined' do
+    let(:project) { create(:project) }
+    let(:user) { create(:user) }
+    let(:user2) { create(:user) }
+
+    it 'returns true if user is there' do
+      project.users = [user]
+      expect(project.joined(user)).to eq(true)
+    end
+
+    it 'returns false if user the project has no users' do
+      project.users = []
+      expect(project.joined(user)).to eq(false)
+    end
+
+    it 'returns false if user is not there' do
+      project.users = [user2]
+      expect(project.joined(user)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
Fixes two sources of  `InvalidAuthenticityToken` exceptions:

1. People clicking repeatedly on `join`/`leave` 
2. People enrolling in an announcement while doing other things

This should somewhat help a bit...