### PR TITLE
Add admin menu for admin users

### DIFF
--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -55,7 +55,7 @@
                 = link_to(destroy_user_ichain_session_path, :method => :delete, :id => "logout-link") do
                   %i.fa.fa-power-off
                   Log out
-              - if current_user.role? :organizer
+              - if current_user.role?(:organizer) || current_user.role?(:admin)
                 = render partial: 'layouts/admin_menu'
         %ul.nav.navbar-nav.navbar-right.visible-xs
           %li{role: "presentation", class: "divider"}


### PR DESCRIPTION
Only organizer could see the admin menu, now admins and organizers can
see it.