### PR TITLE
Add missing foreign_key in users model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :updates, foreign_key: 'author_id', dependent: :destroy
 
   has_many :memberships
-  has_many :comments
+  has_many :comments, foreign_key: 'commenter_id'
   has_many :likes
   has_many :enrollments
 


### PR DESCRIPTION
The relationship of comments of a user was using 'user_id' instead of 'commenter_id'.

Co-authored-by: David Kang <dkang@suse.com>

Fixes #438