### PR TITLE
Change github emoji cdn

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -119,7 +119,7 @@ $(function(){
   var emoji_config = {
     at: ":",
     data: emojis,
-    displayTpl: "<li>${name} <img src='https://assets-cdn.github.com/images/icons/emoji/${key}.png'  height='20' width='20' /></li>",
+    displayTpl: "<li>${name} <img src='https://github.githubassets.com/images/icons/emoji/${key}.png'  height='20' width='20' /></li>",
     insertTpl: ':${key}:',
     delay: 400
   }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -26,7 +26,7 @@ class CommentsController < ApplicationController
   def reply_modal
     @comment = Comment.find(params[:id])
     @content = @comment.text.to_str.gsub(/:([\w+-]+):/) do |match|
-                 %(![add-emoji](https://assets-cdn.github.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))
+                 %(![add-emoji](https://github.githubassets.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))
                end if @comment.text
     @rendered = MarkdownHelper.render @content
     respond_to do |format|

--- a/app/controllers/markdown_controller.rb
+++ b/app/controllers/markdown_controller.rb
@@ -4,7 +4,7 @@ class MarkdownController < ApplicationController
 
   def preview
     markdown_source = params[:source].to_str.gsub(/:([\w+-]+):/) do |match|
-                        %(![add-emoji](https://assets-cdn.github.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))
+                        %(![add-emoji](https://github.githubassets.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))
                       end if params[:source]
     @rendered = MarkdownHelper.render markdown_source
     respond_with @rendered

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
 
   def emojify content
     content.to_str.gsub(/:([\w+-]+):/) do |match|
-      %(![add-emoji](https://assets-cdn.github.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))      
+      %(![add-emoji](https://github.githubassets.com/images/icons/emoji/#{match.to_str.tr(':','')}.png))
     end.html_safe if content.present?
   end
 end


### PR DESCRIPTION
The url for github emoji has changed from `https://assets-cdn.github.com`
`to https://github.githubassets.com`