### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_install:
   - 'wget -nv http://sphinxsearch.com/files/dicts/en.pak'
   - 'sudo apt-get -qq update'
   - 'sudo apt-get install sphinxsearch'
+  - 'gem install bundler'
 before_script:
   - RAILS_ENV=test bundle exec rake dev:bootstrap --trace
 script:


### PR DESCRIPTION
For some reason travis is not installing `bundler` throwing the next
exception: `can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)`
I found a work around looking into this discussion [travis-ci/travis-ci](https://github.com/travis-ci/travis-ci/issues/5239#issuecomment-167355686)