### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
     on_failure: change
 before_install:
   - "echo 'gem: --no-ri --no-rdoc' > ~/.gemrc"
+  - 'gem install bundler -v "$(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)"'
   - 'wget -nv http://sphinxsearch.com/files/dicts/en.pak'
   - 'sudo apt-get -qq update'
   - 'sudo apt-get install sphinxsearch'


### PR DESCRIPTION
Travis was throwing the next exception:
`can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)`
This is happing because RubyGems was unable to find the exact version of Bundler that is in our Gemfile.lock. This bug is fixed in RubyGems 2.7.10, but on Travis we are using 2.7.3. For more information [Bundler Blog](https://bundler.io/blog/2019/05/14/solutions-for-cant-find-gem-bundler-with-executable-bundle.html).