### PR TITLE
Make keyword input required

### DIFF
--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,4 +1,7 @@
 class Keyword < ApplicationRecord
+  validates :name, presence: true
+  validates :name, uniqueness: true
+
   scope :find_keyword, lambda {
     |str| where('lower(name) like ?', "#{str.downcase}%")
   }

--- a/app/views/keywords/_new.html.haml
+++ b/app/views/keywords/_new.html.haml
@@ -1,6 +1,6 @@
 = form_tag :action => "add_keyword", :id => what.id do |f|
   .input-group
-    = text_field_tag :keyword, nil, class: "form-control", id: "tokens", placeholder: "Keyword"
+    = text_field_tag :keyword, nil, class: "form-control", id: "tokens", placeholder: "Keyword", required: true
     %span.input-group-btn
       = button_tag(type: 'submit', class: "btn btn-default") do
         Save


### PR DESCRIPTION
Making it required we improve a little bit the user experience and
also we avoid sending failed requests due to an empty keyword param.