### PR TITLE
Avoid to crash when we don't have episode

### DIFF
--- a/app/views/about/index.html.haml
+++ b/app/views/about/index.html.haml
@@ -11,7 +11,7 @@
           = image_tag 'hackweek-label.png', class: 'img-responsive', alt: 'Hack Week'
 .row
   .col-md-7
-    - if @episode.description.empty?
+    - if @episode.try(:description).blank?
       %p.lead
         Hack Week is the time SUSE engineers experiment, innovate &amp; learn interruption-free
         for a whole week! Across teams or alone, but always without limits.


### PR DESCRIPTION
When we start the app from scrach we don't have episode and we can't
get the description from the episode.