### PR TITLE
Docker was constantly seg-faulting during zypper install. Caused by a…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opensuse/leap:15.0
+FROM opensuse/leap:15.1
 ARG CONTAINER_USERID
 
 # Add needed repos


### PR DESCRIPTION
Docker was constantly seg-faulting during zypper install. Caused by old known bug in curl. Update OpenSuse to 15.1 to fix.

See: https://bugzilla.opensuse.org/show_bug.cgi?id=1127849