### PR TITLE
Fix search by episode

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,8 +6,8 @@ class SearchController < ApplicationController
       @projects = Project.search params[:q]
       @projects = Project.search params[:q], star: true if @projects.empty?
     else
-      @projects = Project.search params[:q], conditions: { episode_id: params[:episode] }
-      @projects = Project.search params[:q], conditions: { episode_id: params[:episode] }, star: true if @projects.empty?
+      @projects = Project.search params[:q], with: { episode_ids: params[:episode].to_i }
+      @projects = Project.search params[:q], with: { episode_ids: params[:episode].to_i }, star: true if @projects.empty?
     end
 
     @users = User.search params[:q]

--- a/app/indices/project_index.rb
+++ b/app/indices/project_index.rb
@@ -2,7 +2,8 @@ ThinkingSphinx::Index.define :project, name: :project_real_time, with: :real_tim
   indexes title
   indexes description
   indexes comment_texts
-  indexes episode_id
+
+  has episode_ids, as: :episode_ids, type: :integer, multi: true
 end
 
 ThinkingSphinx::Index.define :project, name: :project_active_record, with: :active_record do

--- a/app/indices/project_index.rb
+++ b/app/indices/project_index.rb
@@ -5,10 +5,3 @@ ThinkingSphinx::Index.define :project, name: :project_real_time, with: :real_tim
 
   has episode_ids, as: :episode_ids, type: :integer, multi: true
 end
-
-ThinkingSphinx::Index.define :project, name: :project_active_record, with: :active_record do
-  indexes title
-  indexes description
-  indexes comments.text, :as => :comments
-  indexes episodes.id, as: :episode_id
-end

--- a/app/indices/user_index.rb
+++ b/app/indices/user_index.rb
@@ -1,7 +1,3 @@
 ThinkingSphinx::Index.define :user, name: :user_real_time, with: :real_time do
   indexes name
 end
-
-ThinkingSphinx::Index.define :user, name: :user_active_record, with: :active_record do
-  indexes name
-end


### PR DESCRIPTION
After migrating to sphinx real-time indices, the episodes should have been indexed as a multi-value attribute.

Also, after starting to use real-time indices there is no need to also use active record indices.