### PR TITLE
Update mariadb docker container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 version: "2.1"
 services:
   db:
-    image: openbuildservice/mariadb
+    image: registry.opensuse.org/obs/server/unstable/container/leap151/containers/openbuildservice/mariadb
+    command: /usr/lib/mysql/mysql-systemd-helper start
   hackweek:
     build:
       dockerfile: Dockerfile


### PR DESCRIPTION
Switch base system from Leap 42.3 to Leap 15.1.

This way, the base system used in the mariadb container is the same one used in the hackweek container.