### PR TITLE
Update package with development files for MariaDB

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo 'solver.allowVendorChange = true' >> /etc/zypp/zypp.conf; \
 RUN zypper -n install --no-recommends --replacefiles \
   curl vim vim-data psmisc timezone ack glibc-locale sudo hostname \
   sphinx libxml2-devel libxslt-devel sqlite3-devel nodejs8 gcc-c++ \
-  ImageMagick libmysqld-devel ruby-devel make git-core; \
+  ImageMagick libmariadb-devel ruby-devel make git-core; \
   zypper -n clean --all
 
 # Add our user


### PR DESCRIPTION
Prevent this warning to happen:

`'libmysqld-devel' not found in package names. Trying capabilities.`

This made packages `libmariadb-devel` and `libmariadbd-devel` to be installed. The last one turns out not to be necessary.

The development files for MariaDB contained in the `libmariadb-devel` package, are only used to install the `mysql2` gem.