### PR TITLE
Escape query parameter in searches

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -2,17 +2,18 @@ class SearchController < ApplicationController
   skip_before_action :authenticate_user!, only: [:result]
   def result
     # First search in morphology mode, if fails — retry in wildcard mode
+    search_query = ThinkingSphinx::Query.escape(params[:q])
     if @episode.to_param == 'all'
-      @projects = Project.search params[:q]
-      @projects = Project.search params[:q], star: true if @projects.empty?
+      @projects = Project.search search_query
+      @projects = Project.search search_query, star: true if @projects.empty?
     else
-      @projects = Project.search params[:q], with: { episode_ids: params[:episode].to_i }
+      @projects = Project.search search_query, with: { episode_ids: params[:episode].to_i }
       if @projects.empty?
-        @projects = Project.search params[:q], with: { episode_ids: params[:episode].to_i }, star: true
+        @projects = Project.search search_query, with: { episode_ids: params[:episode].to_i }, star: true
       end
     end
 
-    @users = User.search params[:q]
-    @users = User.search params[:q], star: true if @users.empty?
+    @users = User.search search_query
+    @users = User.search search_query, star: true if @users.empty?
   end
 end


### PR DESCRIPTION
Prevent crashing in search terms including `/`.

Fixes #707.