### PR TITLE
Don't cut markdown preview after 140 chars

### DIFF
--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -2,4 +2,8 @@ module MarkdownHelper
   def self.render(markdown_source)
     Haml::Filters::Markdown.render markdown_source
   end
+
+  def mdpreview(markdown_source, lines: 3)
+    markdown_source.lines.reject { |l| l =~ /\[comment\]/ }.select { |l| l =~ /\S/ }[0..lines].join
+  end
 end

--- a/app/views/projects/_list_item.html.haml
+++ b/app/views/projects/_list_item.html.haml
@@ -11,7 +11,7 @@
       #{project.originator.name}
       = render :partial => "projects/like_button", :locals => {:project => project }
 :markdown
-  #{truncate(project.description, length: 140)}
+  #{mdpreview(project.description, lines: 3)}
 - unless project.users.empty?
   .well.well-sm
     - project.users.each do |user|


### PR DESCRIPTION
Don't cut markdown preview after 140 chars, which can lead to invalid syntax. Cut after n lines instead and filter out comments and empty lines.