### PR TITLE
Fix restart during deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -35,7 +35,8 @@ task :deploy do
 
     on :launch do
       in_path(fetch(:current_path)) do
-        command %{bundle exec pumactl restart -e production}
+        command %{sudo systemctl restart hackweek}
+        command %{sudo systemctl restart hackweek-sphinx}
       end
     end
   end


### PR DESCRIPTION
pumactl restart does not make the worker re-read their
working directory. Hence new code is never used...

Use stop/start via systemd again.