### PR TITLE
Fix spam detection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -45,7 +45,7 @@ Metrics/BlockLength:
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 199
+  Max: 201
 
 # Offense count: 2
 # Configuration parameters: IgnoredMethods.

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,13 +1,17 @@
 class Comment < ApplicationRecord
   include Rails.application.routes.url_helpers
   include Rakismet::Model
+  include AkismetValidation
 
   belongs_to :commentable, polymorphic: true
   has_many :comments, as: :commentable, dependent: :destroy
 
   belongs_to :commenter, class_name: 'User'
+  alias_attribute :originator, :commenter
 
   validates_presence_of :commenter_id, :text, :commentable_id
+  validate :akismet_spam
+
   ThinkingSphinx::Callbacks.append(self, behaviours: [:real_time])
 
   def project

--- a/app/models/concerns/akismet_validation.rb
+++ b/app/models/concerns/akismet_validation.rb
@@ -1,0 +1,12 @@
+module AkismetValidation
+  extend ActiveSupport::Concern
+
+  def akismet_spam
+    return unless Rails.env.production?
+    return unless spam?
+    return if originator.email.end_with?('@suse.com')
+    return if originator.email.end_with?('@opensuse.org')
+
+    errors.add(:base, message: 'is spam')
+  end
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -2,10 +2,12 @@ class Project < ApplicationRecord
   include AASM
   include Rails.application.routes.url_helpers
   include Rakismet::Model
+  include AkismetValidation
 
   validates :title, :description, :originator, presence: true
   validate  :title_contains_letters?
   validates :url, uniqueness: true
+  validate :akismet_spam
 
   belongs_to :originator, class_name: 'User'
 


### PR DESCRIPTION
Adding errors to an instatiated object has no effect on it's validity, so
this never prevented spam from being saved.

Also moves akismet validation to a concern. No need to do this in the
controller, I've misunderstood the docu.

Adds allowlist for @suse.com and @opensuse.org addresses...