### PR TITLE
Hide e-mail addresses from anonymous views

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,7 +14,7 @@
       %p
         %i{class: 'fas fa-home', title: 'Location'}
         = @user.location
-    - unless (!current_user or @user.hide_email?)
+    - if current_user && !@user.hide_email?
       %p
         %i{class: 'fas fa-envelope', title: 'Email'}
         = mail_to @user.email

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,7 +14,7 @@
       %p
         %i{class: 'fas fa-home', title: 'Location'}
         = @user.location
-    - unless @user.hide_email?
+    - unless (!current_user or @user.hide_email?)
       %p
         %i{class: 'fas fa-envelope', title: 'Email'}
         = mail_to @user.email


### PR DESCRIPTION
if there is no user logged in, do not show the email address of other users even if the hide_email flag is not set. This avoids scrapers and search engines picking it up.