### PR TITLE
Fix image overflow in project body

### DIFF
--- a/app/assets/stylesheets/hackweek.scss
+++ b/app/assets/stylesheets/hackweek.scss
@@ -208,6 +208,9 @@ table.project_table td {
     small {
       font-size: 12px;
     }
+    img {
+      max-width: 100%;
+    }
   }
   ul, ol {
     margin-top: 10px;


### PR DESCRIPTION
Images embedded in the project body, which are wider than the body itself, will overflow into the side panel. This simple fix limits the max width of images to 100% of the parent container.