### PR TITLE
Add margin to image in dropdown notifications

### DIFF
--- a/app/assets/stylesheets/hackweek.scss
+++ b/app/assets/stylesheets/hackweek.scss
@@ -38,6 +38,7 @@ body {
           img{
             max-height: 30px;
             width: auto;
+            margin-right: 1.5rem;
           }
         }
       }


### PR DESCRIPTION
This fixes ugly (non-existing) image spacing in dropdown notifications when the project has a logo.

Before:
![img-before](https://github.com/user-attachments/assets/83369505-7166-42c5-b23e-cd97c62f98a5)

After:
![img-after](https://github.com/user-attachments/assets/596c3354-dc16-4147-adc2-48bffc6eda14)
