### PR TITLE
Cleanup Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,31 +8,6 @@ gem 'sprockets-rails'
 # as the app server
 gem 'puma'
 
-group :development, :test do
-  # as our rails console
-  gem 'pry-byebug'
-  gem 'pry-rails'
-  # to improve inspect output
-  gem 'hirb'
-end
-
-group :test do
-  # for cleaning the test DB
-  gem 'database_cleaner'
-  # for measuring test coverage
-  gem 'coveralls', require: false
-  # as style hound
-  gem 'rubocop'
-  gem 'rubocop-capybara'
-  gem 'rubocop-factory_bot'
-  gem 'rubocop-rails'
-  gem 'rubocop-rspec'
-  # for time travel in tests
-  gem 'timecop'
-  # for feature tests
-  gem 'webdrivers'
-end
-
 # as databases
 gem 'mysql2'
 # for stylesheets
@@ -78,13 +53,6 @@ gem 'thinking-sphinx'
 gem 'kaminari'
 # for slugs
 gem 'stringex'
-# for seeds
-gem 'factory_bot_rails', group: %i[development test]
-gem 'faker', group: %i[development test]
-# as test framework
-gem 'capybara', group: %i[development test]
-gem 'rails-controller-testing', group: %i[development test]
-gem 'rspec-rails', group: %i[development test]
 # as deployer
 gem 'mina'
 # as the log formater
@@ -99,3 +67,31 @@ gem 'logger'
 gem 'mutex_m'
 gem 'ostruct'
 gem 'reline'
+
+# for seeds
+gem 'factory_bot_rails', group: %i[development test]
+gem 'faker', group: %i[development test]
+# as test framework
+gem 'capybara', group: %i[development test]
+gem 'rails-controller-testing', group: %i[development test]
+gem 'rspec-rails', group: %i[development test]
+# as our rails console
+gem 'pry-byebug', group: %i[development test]
+gem 'pry-rails', group: %i[development test]
+# to improve inspect output
+gem 'hirb', group: %i[development test]
+
+# for cleaning the test DB
+gem 'database_cleaner', group: :test
+# for measuring test coverage
+gem 'coveralls', require: false, group: :test
+# as style hound
+gem 'rubocop', group: :test
+gem 'rubocop-capybara', group: :test
+gem 'rubocop-factory_bot', group: :test
+gem 'rubocop-rails', group: :test
+gem 'rubocop-rspec', group: :test
+# for time travel in tests
+gem 'timecop', group: :test
+# for feature tests
+gem 'webdrivers', group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -59,14 +59,9 @@ gem 'mina'
 gem 'lograge'
 # for listening to file modifications
 gem 'listen'
-# explicit dependencies required by rspec
-gem 'benchmark'
+# FIXME: activesupport-7.0.8.7 expects those to be in the standard library, which they aren't anymore since 3.4.0
 gem 'drb'
-gem 'irb'
-gem 'logger'
 gem 'mutex_m'
-gem 'ostruct'
-gem 'reline'
 
 # for seeds
 gem 'factory_bot_rails', group: %i[development test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,4 +487,4 @@ DEPENDENCIES
   webdrivers
 
 BUNDLED WITH
-   2.5.16
+   2.6.9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,6 @@ GEM
       execjs (~> 2)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    benchmark (0.4.0)
     bigdecimal (3.1.9)
     bootstrap-sass (3.4.1)
       autoprefixer-rails (>= 5.2.1)
@@ -119,7 +118,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.1)
     drb (2.2.3)
-    erb (5.0.1)
     erubi (1.13.1)
     execjs (2.10.0)
     factory_bot (6.5.0)
@@ -150,11 +148,6 @@ GEM
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
     innertube (1.1.0)
-    io-console (0.8.1)
-    irb (1.15.2)
-      pp (>= 0.6.0)
-      rdoc (>= 4.0.0)
-      reline (>= 0.4.2)
     joiner (0.6.0)
       activerecord (>= 6.1.0)
     jquery-atwho-rails (1.5.4)
@@ -184,7 +177,6 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.7.0)
     lograge (0.14.0)
       actionpack (>= 4)
       activesupport (>= 4)
@@ -224,14 +216,10 @@ GEM
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     orm_adapter (0.5.0)
-    ostruct (0.6.3)
     parallel (1.27.0)
     parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
-    pp (0.6.2)
-      prettyprint
-    prettyprint (0.2.0)
     prism (1.4.0)
     pry (0.15.2)
       coderay (~> 1.1)
@@ -241,9 +229,6 @@ GEM
       pry (>= 0.13, < 0.16)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.2.6)
-      date
-      stringio
     public_suffix (6.0.1)
     puma (6.6.1)
       nio4r (~> 2.0)
@@ -288,13 +273,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.14.0)
-      erb
-      psych (>= 4.0.0)
     redcarpet (3.6.1)
     regexp_parser (2.10.0)
-    reline (0.6.2)
-      io-console (~> 0.5)
     request_store (1.7.0)
       rack (>= 1.4)
     responders (3.1.1)
@@ -385,7 +365,6 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringex (2.8.6)
-    stringio (3.1.7)
     sync (0.5.0)
     temple (0.10.3)
     term-ansicolor (1.11.2)
@@ -431,7 +410,6 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  benchmark
   bootstrap-sass
   cancancan
   capybara
@@ -447,27 +425,23 @@ DEPENDENCIES
   gravtastic
   haml-rails
   hirb
-  irb
   jquery-atwho-rails
   jquery-hotkeys-rails
   jquery-rails
   js_cookie_rails
   kaminari
   listen
-  logger
   lograge
   mina
   mousetrap-rails
   mutex_m
   mysql2
-  ostruct
   pry-byebug
   pry-rails
   puma
   rails (~> 7.0.1)
   rails-controller-testing
   redcarpet
-  reline
   rouge
   rspec-rails
   rubocop


### PR DESCRIPTION
- Only directly require what we really require
- Bundle with the bundler version our openSUSE ruby package ships
- Stop mixing group block and group opt feature