### PR TITLE
Introduces Comment.ham to mark comments as ham

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -83,7 +83,9 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns, inherit_mode.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 77
+  Max: 35
+  Exclude:
+    - 'config/routes.rb'
 
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:reply_modal]
 
   def index
-    @comments = Comment.accessible_by(current_ability).order(id: :desc).page(params[:page])
+    @comments = Comment.accessible_by(current_ability).where(ham: false).order(id: :desc).page(params[:page])
   end
 
   def create
@@ -39,6 +39,13 @@ class CommentsController < ApplicationController
 
     respond_to do |format|
       format.html { redirect_to comments_path, notice: 'Comment was successfully deleted.' }
+    end
+  end
+
+  def mark_as_ham
+    @comment.update(ham: true)
+    respond_to do |format|
+      format.html { redirect_to comments_path, notice: 'Comment was successfully marked as ham.' }
     end
   end
 

--- a/app/views/comments/index.html.haml
+++ b/app/views/comments/index.html.haml
@@ -27,17 +27,19 @@
                   = comment.text
                 %td
                   - if comment.commentable
-                    = link_to project_path(comment.commentable) do
+                    = link_to project_path('all', comment.project) do
                       = comment.project.title
                   - else
                     Deleted Project/Comment
                 %td
                   .btn-group
                     = link_to comment_path(comment), method: :delete, data: { confirm: 'Are you sure you want to delete this comment?' }, class: 'btn btn-danger' do
-                      Delete Comment
+                      Spam
+                    = link_to mark_as_ham_comment_path(comment), method: :patch, class: 'btn btn-success' do
+                      Ham
           .row
             .col-sm-12
               .text-center
                 = paginate @comments
     - else
-      No comments yet.
+      No comments to moderate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,10 @@ Rails.application.routes.draw do
   end
 
   resources :comments, only: %i[index destroy] do
+    member do
+      patch 'mark_as_ham'
+    end
+
     resources :comments, only: %i[create update]
     collection do
       get '/reply/:id', to: 'comments#reply_modal', as: 'reply_modal'

--- a/db/migrate/20251021103843_add_ham_to_comments.rb
+++ b/db/migrate/20251021103843_add_ham_to_comments.rb
@@ -1,0 +1,5 @@
+class AddHamToComments < ActiveRecord::Migration[7.2]
+  def change
+    add_column :comments, :ham, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_02_01_134703) do
+ActiveRecord::Schema[7.2].define(version: 2025_10_21_103843) do
 
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -55,6 +55,7 @@ ActiveRecord::Schema.define(version: 2022_02_01_134703) do
     t.integer "commenter_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "ham"
   end
 
   create_table "enrollments", id: :integer, charset: "latin1", options: "ENGINE=InnoDB ROW_FORMAT=DYNAMIC", force: :cascade do |t|

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+describe CommentsController do
+  let(:user) { create(:admin) }
+
+  before do
+    sign_in user
+  end
+
+  describe 'GET index' do
+    let!(:ham_comment) { create(:comment, ham: true) }
+
+    before { create(:comment) }
+
+    it 'assigns un-moderated comments as @comments' do
+      get :index
+      expect(assigns(:comments)).not_to include(ham_comment)
+    end
+  end
+
+  describe 'POST mark_as_ham' do
+    let(:comment) { create(:comment) }
+
+    it 'marks the comment as ham' do
+      patch :mark_as_ham, params: { id: comment.id }
+      expect(comment.reload.ham).to be_truthy
+    end
+  end
+end


### PR DESCRIPTION
Turns /comments into a moderation queue for comments no one has moderated yet.
Makes it easier to collaborate on moderation.

<img width="1178" height="332" alt="Screenshot From 2025-10-21 13-16-47" src="https://github.com/user-attachments/assets/32d4a0df-199b-4962-8ee0-afbf89388c34" />

Clicking spam deletes the comment, clicking ham removes it from the moderation queue
